### PR TITLE
fix: ESP8266 compatibility

### DIFF
--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -119,7 +119,7 @@ void JLed::Update() {
     // wait until delay_before time is elapsed before actually doing anything
     if (delay_before_ > 0) {
         delay_before_ =
-            max(0, static_cast<int64_t>(delay_before_) - delta_time);  // NOLINT
+            max(static_cast<int64_t>(0), static_cast<int64_t>(delay_before_) - delta_time);  // NOLINT
         if (delay_before_ > 0) return;
     }
 


### PR DESCRIPTION
See: https://github.com/kitesurfer1404/WS2812FX/issues/58#issuecomment-355793296
```With v2.4.0 min() and max() are now implemented using the std::min and std::max library and both function parameters have to be the same data type, the compiler won't do implicit type conversion```