### PR TITLE
Add UpdateAll class method

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,14 +270,9 @@ Info on how to run the host based provided unit tests
 [is provided here](test/README.md).
 
 ## Important note about this version
-Al Willaims (@wd5gnr) modified this version to maintain a linked list of JLed objects
-to support UpdateAll. However, this causes an issue with some of the example code.
+Al Williams (@wd5gnr) modified this version to maintain a linked list of JLed objects
+to support UpdateAll. 
 
-If you create a global object and then call things like `.forever()` or `.breathe()`
-on it, it will cause the constructor to get an incorrect this pointer. In previous versions
-the this pointer wasn't used, so this wasn't an issue. The solution is to call
-the methods in `setup()` or some other initialization code. See the multiled2 example for
-more about this.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ the `File` > `Examples` > `JLed` menu.
 Info on how to run the host based provided unit tests 
 [is provided here](test/README.md).
 
+## Important note about this version
+Al Willaims (@wd5gnr) modified this version to maintain a linked list of JLed objects
+to support UpdateAll. However, this causes an issue with some of the example code.
+
+If you create a global object and then call things like `.forever()` or `.breathe()`
+on it, it will cause the constructor to get an incorrect this pointer. In previous versions
+the this pointer wasn't used, so this wasn't an issue. The solution is to call
+the methods in `setup()` or some other initialization code. See the multiled2 example for
+more about this.
+
 ## Author
 
 Jan Delgado, jdelgado[at]gmx.net.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ lib_deps=jled
 
 First the LED object is constructed and configured, then the state is updated
 with subsequent calls to the `Update()` method, typically from the `loop()`
-function. The constructor takes the pin, to which the LED is connected to as
+function. The class maintains a list of all JLed objects so if you want to update them all
+you can call `JLed::UpdateAll()` instead. The constructor takes the pin, to which the LED is connected to as
 only parameter. Further configuration of the LED object is done using a fluent
 interface, e.g. `JLed led = JLed(13).Breathe(2000).DelayAfter(1000).Repeat(5)`.
 See examples and [Parameter overview](#parameter-oveview) section below for

--- a/examples/multiled2/breathe-jled.ino
+++ b/examples/multiled2/breathe-jled.ino
@@ -1,0 +1,28 @@
+#include <jled.h>
+
+
+// For some reason, making the setup calls here before elaboration completes
+// causes the this pointer in the JLed constructor to be wrong
+// I didn't track that down, but the answer is to make the calls post main.
+JLed led = JLed(11); //.Breathe(2000).DelayAfter(1000).Forever();
+JLed led1 = JLed(13); //.Blink(500,500).Forever();
+
+
+
+
+
+
+void setup() { 
+   led.Breathe(2000).DelayAfter(1000).Forever();
+   led1.Blink(500,500).Forever();
+
+
+}
+
+
+
+void loop() {
+  
+
+  JLed::UpdateAll();
+} 

--- a/examples/multiled2/breathe-jled.ino
+++ b/examples/multiled2/breathe-jled.ino
@@ -1,11 +1,8 @@
 #include <jled.h>
 
 
-// For some reason, making the setup calls here before elaboration completes
-// causes the this pointer in the JLed constructor to be wrong
-// I didn't track that down, but the answer is to make the calls post main.
-JLed led = JLed(11); //.Breathe(2000).DelayAfter(1000).Forever();
-JLed led1 = JLed(13); //.Blink(500,500).Forever();
+JLed led = JLed(11).Breathe(2000).DelayAfter(1000).Forever();
+JLed led1 = JLed(13).Blink(500,500).Forever();
 
 
 
@@ -13,16 +10,10 @@ JLed led1 = JLed(13); //.Blink(500,500).Forever();
 
 
 void setup() { 
-   led.Breathe(2000).DelayAfter(1000).Forever();
-   led1.Blink(500,500).Forever();
-
-
 }
 
 
 
 void loop() {
-  
-
   JLed::UpdateAll();
 } 

--- a/examples/multiled2/breathe-jled.ino
+++ b/examples/multiled2/breathe-jled.ino
@@ -1,18 +1,14 @@
+// JLed multi LED demo. control multiple LEDs in-sync.
+// Copyright 2017 by Jan Delgado, Al Williams. All rights reserved.
+// https://github.com/jandelgado/jled
+
 #include <jled.h>
 
-
 JLed led = JLed(11).Breathe(2000).DelayAfter(1000).Forever();
-JLed led1 = JLed(13).Blink(500,500).Forever();
-
-
-
-
-
+JLed led1 = JLed(13).Blink(500, 500).Forever();
 
 void setup() { 
 }
-
-
 
 void loop() {
   JLed::UpdateAll();

--- a/examples/multiled2/breathe-jled.ino
+++ b/examples/multiled2/breathe-jled.ino
@@ -7,9 +7,9 @@
 JLed led = JLed(11).Breathe(2000).DelayAfter(1000).Forever();
 JLed led1 = JLed(13).Blink(500, 500).Forever();
 
-void setup() { 
+void setup() {
 }
 
 void loop() {
   JLed::UpdateAll();
-} 
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -32,6 +32,7 @@ LowActive	KEYWORD2
 Invert	KEYWORD2
 Stop	KEYWORD2
 Update	KEYWORD2
+UpdateAll	KEYWORD2
 UserFunc	KEYWORD2
 
 #######################################

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=JLed
-version=3.0.0
+version=2.2.4
 author=Jan Delgado <jdelgado[at]gmx.net>
 maintainer=Jan Delgado <jdelgado[at]gmx.net>
 sentence=An Arduino library to control LEDs (modified)

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=JLed
-version=2.2.3
+version=3.0.0
 author=Jan Delgado <jdelgado[at]gmx.net>
 maintainer=Jan Delgado <jdelgado[at]gmx.net>
-sentence=An Arduino library to control LEDs
+sentence=An Arduino library to control LEDs (modified)
 paragraph=JLed uses a non-blocking approach and can control LEDs in simple (on/off) and complex (blinking, breathing) ways in a time-driven manner.
 category=Other
 url=https://github.com/jandelgado/jled

--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -57,7 +57,7 @@ JLed::JLed(uint8_t led_pin) : led_pin_(led_pin) {
   next = nullptr;
 }
 
-JLed::JLed(const JLed &jled) {
+JLed::JLed(JLed &jled) {
   JLed *p;
   next = &jled;
   if (head && head == &jled) {

--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -60,6 +60,7 @@ JLed::JLed(uint8_t led_pin) : led_pin_(led_pin) {
 JLed::JLed(const JLed &jled) {
   JLed *p;
   if (head && head == &jled) {
+    next = head;
     head = this;
   } else {
     for (p = head; p&&p->next&&p->next != &jled; p = p->next) {}

--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -57,7 +57,7 @@ JLed::JLed(uint8_t led_pin) : led_pin_(led_pin) {
   next = nullptr;
 }
 
-JLed::JLed(JLed &jled) {
+JLed::JLed(const JLed &jled) {
   JLed *p;
   next = &jled;
   if (head && head == &jled) {

--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -28,19 +28,17 @@
 
 constexpr uint8_t JLed::kFadeOnTable[];
 
-JLed *JLed::head = (JLed *)0;
+JLed *JLed::head = nullptr;
 
 
 
-JLed::~JLed()
-{
+JLed::~JLed() {
   // remove from linked list
-  JLed *p,*last=head;
-  if (head==this) head=next;
-  else
-    {
-      for (p=head;p&&p!=this;p=p->next) last=p;
-      if (last) last->next=next;
+  JLed *p, *last = head;
+  if (head == this) head=next;
+  else   {
+      for (p = head;p&&p != this;p = p->next) last = p;
+      if (last) last->next = next;
     }
   
 }
@@ -50,38 +48,37 @@ JLed::JLed(uint8_t led_pin) : led_pin_(led_pin) {
   JLed *p;
   pinMode(led_pin, OUTPUT);
   // add to linked list
-  if (!head) head=this;
+  if (!head) head = this;
   else
     {
-      for (p=head;p->next;p=p->next);
-      p->next=this;
+      for (p = head;p->next;p = p->next);
+      p->next = this;
     }
   next=(JLed *)0;
   
 }
 
-JLed::JLed(const JLed &jled) 
-{
+JLed::JLed(const JLed &jled) {
   JLed *p;
-  next=&jled;
-  if (head && head==&jled)
-    head=this;
+  next = &jled;
+  if (head && head == &jled)
+    head = this;
   else
     {
-      for (p=head;p&&p->next&&p->next!=&jled;p=p->next);
-      if (p) p->next=this;
+      for (p = head;p&&p->next&&p->next != &jled;p = p->next);
+      if (p) p->next = this;
     }
   
-  brightness_func_=jled.brightness_func_;
-  effect_param_=jled.effect_param_;
-  flags_=jled.flags_;
-  led_pin_=jled.led_pin_;
-  num_repetitions_=jled.num_repetitions_;
-  last_update_time_=jled.last_update_time_;
-  delay_before_=jled.delay_before_;
-  delay_after_=jled.delay_after_;
-  time_start_=jled.time_start_;
-  period_=jled.period_;
+  brightness_func_ = jled.brightness_func_;
+  effect_param_ = jled.effect_param_;
+  flags_ = jled.flags_;
+  led_pin_ = jled.led_pin_;
+  num_repetitions_ = jled.num_repetitions_;
+  last_update_time_ = jled.last_update_time_;
+  delay_before_ = jled.delay_before_;
+  delay_after_ = jled.delay_after_;
+  time_start_ = jled.time_start_;
+  period_ = jled.period_;
 
   
 }

--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -35,12 +35,12 @@ JLed *JLed::head = nullptr;
 JLed::~JLed() {
   // remove from linked list
   JLed *p, *last = head;
-  if (head == this) head=next;
-  else   {
-      for (p = head;p&&p != this;p = p->next) last = p;
+  if (head == this) {
+    head=next;
+  } else   {
+      for (p = head; p&&p != this; p = p->next) last = p;
       if (last) last->next = next;
     }
-  
 }
 
 
@@ -49,13 +49,11 @@ JLed::JLed(uint8_t led_pin) : led_pin_(led_pin) {
   pinMode(led_pin, OUTPUT);
   // add to linked list
   if (!head) head = this;
-  else
-    {
-      for (p = head;p->next;p = p->next);
+  else   {
+    for (p = head; p->next; p = p->next) {}
       p->next = this;
     }
-  next=(JLed *)0;
-  
+  next=nullptr;
 }
 
 JLed::JLed(const JLed &jled) {
@@ -63,12 +61,10 @@ JLed::JLed(const JLed &jled) {
   next = &jled;
   if (head && head == &jled)
     head = this;
-  else
-    {
-      for (p = head;p&&p->next&&p->next != &jled;p = p->next);
+  else  {
+    for (p = head; p&&p->next&&p->next != &jled; p = p->next) {}
       if (p) p->next = this;
     }
-  
   brightness_func_ = jled.brightness_func_;
   effect_param_ = jled.effect_param_;
   flags_ = jled.flags_;
@@ -79,8 +75,6 @@ JLed::JLed(const JLed &jled) {
   delay_after_ = jled.delay_after_;
   time_start_ = jled.time_start_;
   period_ = jled.period_;
-
-  
 }
 
 
@@ -208,10 +202,9 @@ void JLed::Update() {
     }
 }
 
-void JLed::UpdateAll()
-{
+void JLed::UpdateAll() {
   JLed *p;
-  for (p=head;p;p=p->next) p->Update();
+  for (p=head; p; p=p->next) p->Update();
 }
 
 

--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -28,7 +28,8 @@
 
 constexpr uint8_t JLed::kFadeOnTable[];
 
-static JLed *JLed::head = NULL;
+JLed *JLed::head = (JLed *)0;
+
 
 JLed::~JLed()
 {
@@ -54,7 +55,7 @@ JLed::JLed(uint8_t led_pin) : led_pin_(led_pin) {
       for (p=head;p->next;p=p->next);
       p->next=this;
     }
-  next=NULL;
+  next=(JLed *)0;
 }
 
 

--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -59,13 +59,16 @@ JLed::JLed(uint8_t led_pin) : led_pin_(led_pin) {
 
 JLed::JLed(const JLed &jled) {
   JLed *p;
-  next = &jled;
   if (head && head == &jled) {
     head = this;
   } else {
     for (p = head; p&&p->next&&p->next != &jled; p = p->next) {}
-      if (p) p->next = this;
+    if (p) {
+      JLed *p0=p->next; // p0 now points to jled but not const!
+      p->next = this;
+      next=p0;
     }
+  }
   brightness_func_ = jled.brightness_func_;
   effect_param_ = jled.effect_param_;
   flags_ = jled.flags_;

--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -64,9 +64,9 @@ JLed::JLed(const JLed &jled) {
   } else {
     for (p = head; p&&p->next&&p->next != &jled; p = p->next) {}
     if (p) {
-      JLed *p0=p->next; // p0 now points to jled but not const!
+      JLed *p0 = p->next;  // p0 now points to jled but not const!
       p->next = this;
-      next=p0;
+      next = p0;
     }
   }
   brightness_func_ = jled.brightness_func_;

--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -36,7 +36,7 @@ JLed::~JLed() {
   // remove from linked list
   JLed *p, *last = head;
   if (head == this) {
-    head=next;
+    head = next;
   } else   {
       for (p = head; p&&p != this; p = p->next) last = p;
       if (last) last->next = next;
@@ -48,20 +48,21 @@ JLed::JLed(uint8_t led_pin) : led_pin_(led_pin) {
   JLed *p;
   pinMode(led_pin, OUTPUT);
   // add to linked list
-  if (!head) head = this;
-  else   {
+  if (!head) {
+    head = this;
+  } else {
     for (p = head; p->next; p = p->next) {}
       p->next = this;
     }
-  next=nullptr;
+  next = nullptr;
 }
 
 JLed::JLed(const JLed &jled) {
   JLed *p;
   next = &jled;
-  if (head && head == &jled)
+  if (head && head == &jled) {
     head = this;
-  else  {
+  } else {
     for (p = head; p&&p->next&&p->next != &jled; p = p->next) {}
       if (p) p->next = this;
     }

--- a/src/jled.cpp
+++ b/src/jled.cpp
@@ -31,6 +31,7 @@ constexpr uint8_t JLed::kFadeOnTable[];
 JLed *JLed::head = (JLed *)0;
 
 
+
 JLed::~JLed()
 {
   // remove from linked list
@@ -56,7 +57,35 @@ JLed::JLed(uint8_t led_pin) : led_pin_(led_pin) {
       p->next=this;
     }
   next=(JLed *)0;
+  
 }
+
+JLed::JLed(const JLed &jled) 
+{
+  JLed *p;
+  next=&jled;
+  if (head && head==&jled)
+    head=this;
+  else
+    {
+      for (p=head;p&&p->next&&p->next!=&jled;p=p->next);
+      if (p) p->next=this;
+    }
+  
+  brightness_func_=jled.brightness_func_;
+  effect_param_=jled.effect_param_;
+  flags_=jled.flags_;
+  led_pin_=jled.led_pin_;
+  num_repetitions_=jled.num_repetitions_;
+  last_update_time_=jled.last_update_time_;
+  delay_before_=jled.delay_before_;
+  delay_after_=jled.delay_after_;
+  time_start_=jled.time_start_;
+  period_=jled.period_;
+
+  
+}
+
 
 
 JLed& JLed::SetFlags(uint8_t f, bool val) {

--- a/src/jled.h
+++ b/src/jled.h
@@ -49,6 +49,7 @@ class JLed {
 
     JLed() = delete;
     explicit JLed(uint8_t led_pin);
+    JLed(const JLed &jled);
     ~JLed();
 
     // call Update() from the loop() function to update LED state.

--- a/src/jled.h
+++ b/src/jled.h
@@ -49,7 +49,7 @@ class JLed {
 
     JLed() = delete;
     explicit JLed(uint8_t led_pin);
-    JLed(const JLed &jled);
+    JLed(JLed &jled);
     ~JLed();
 
     // call Update() from the loop() function to update LED state.

--- a/src/jled.h
+++ b/src/jled.h
@@ -49,9 +49,11 @@ class JLed {
 
     JLed() = delete;
     explicit JLed(uint8_t led_pin);
+    ~JLed();
 
     // call Update() from the loop() function to update LED state.
     void Update();
+    static void UpdateAll();
 
     // turn LED on, respecting delay_before
     JLed& On();
@@ -143,6 +145,9 @@ class JLed {
     // LED breathe effect. Composition of fade-on and fade-off with half
     // the period each.
     static uint8_t BreatheFunc(uint32_t t, uint16_t period, uintptr_t);
+    JLed *next;
+    static JLed *head;
+    
 
  private:
     // pre-calculated fade-on function. This table samples the function

--- a/src/jled.h
+++ b/src/jled.h
@@ -147,7 +147,7 @@ class JLed {
     // LED breathe effect. Composition of fade-on and fade-off with half
     // the period each.
     static uint8_t BreatheFunc(uint32_t t, uint16_t period, uintptr_t);
-    JLed const *next;
+    JLed *next;
     static JLed *head;
 
  private:

--- a/src/jled.h
+++ b/src/jled.h
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2017 Jan Delgado <jdelgado[at]gmx.net>
 // https://github.com/jandelgado/jled
 //
@@ -49,7 +50,7 @@ class JLed {
 
     JLed() = delete;
     explicit JLed(uint8_t led_pin);
-    JLed(JLed &jled);
+    JLed(const JLed &jled);
     ~JLed();
 
     // call Update() from the loop() function to update LED state.
@@ -146,7 +147,7 @@ class JLed {
     // LED breathe effect. Composition of fade-on and fade-off with half
     // the period each.
     static uint8_t BreatheFunc(uint32_t t, uint16_t period, uintptr_t);
-    JLed *next;
+    JLed const *next;
     static JLed *head;
 
  private:

--- a/src/jled.h
+++ b/src/jled.h
@@ -148,7 +148,6 @@ class JLed {
     static uint8_t BreatheFunc(uint32_t t, uint16_t period, uintptr_t);
     JLed *next;
     static JLed *head;
-    
 
  private:
     // pre-calculated fade-on function. This table samples the function


### PR DESCRIPTION
I thought it would be simple to let JLed keep a static linked list of all known instances. This allows you to create an UpdateAll that gets all the objects that exist with one call.

There was one problem. Many of the examples use a global object and them make member calls against it:

JLed led(11).breathe(....).....;

Doing this causes the this pointer in the constructor to be incorrect. I'm not sure why.  I think this is a problem even without my changes, but since the existing constructor doesn't make use of the this pointer, no one notices it. Look at examples/multiled2 to see what I mean.

What I did not do was go back and patch all the other examples. However, if you don't call UpdateAll, it won't matter if the linked list is busted or not.
