### PR TITLE
lazy pinMode() initialization for standard arduino JLed HAL implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ ci:
 	platformio ci $(CIOPTSALL) examples/fade_on/fade_on.ino
 	platformio ci $(CIOPTSALL) examples/sequence/sequence.ino 
 
+envdump:
+	-pio run --target envdump
+
 clean:
 	-pio run --target clean
 	rm -f {test,src}/{*.o,*.gcno,*.gcda}

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [platformio]
 env_default = nanoatmega328
 ;env_default = nucleo_f401re
-;env_default = esp8266;
+;env_default = esp8266
 ;env_default = esp32
 
 ; uncomment example to build
@@ -39,6 +39,7 @@ board = nucleo_f401re
 framework = arduino
 build_flags = -Isrc
 src_filter = +<../../src/>  +<./>
+upload_protocol=stlink
 
 [env:esp8266]
 platform = espressif8266

--- a/src/arduino_hal.h
+++ b/src/arduino_hal.h
@@ -23,20 +23,28 @@
 #define SRC_ARDUINO_HAL_H_
 
 #include <Arduino.h>
-#include "jled_hal.h"   // NOLINT
+#include "jled_hal.h"  // NOLINT
 
 namespace jled {
 
 class ArduinoHal : JLedHal {
  public:
     ArduinoHal() {}
-    explicit ArduinoHal(uint8_t pin) noexcept : pin_(pin) {
-        ::pinMode(pin_, OUTPUT);
+    explicit ArduinoHal(uint8_t pin) noexcept : pin_(pin) {}
+
+    void analogWrite(uint8_t val) const {
+        // some platforms, e.g. STM need lazy initialization
+        if (!setup_) {
+            ::pinMode(pin_, OUTPUT);
+            setup_ = true;
+        }
+        ::analogWrite(pin_, val);
     }
-    void analogWrite(uint8_t val) { ::analogWrite(pin_, val); }
-    uint32_t millis() {return ::millis();}
+
+    uint32_t millis() const { return ::millis(); }
 
  private:
+    mutable bool setup_ = false;
     uint8_t pin_;
 };
 }  // namespace jled

--- a/src/esp32_hal.h
+++ b/src/esp32_hal.h
@@ -49,8 +49,8 @@ class Esp32Hal /*: public AnalogWriter */ {
         ::ledcSetup(chan_, freq, kLedcTimer8Bit);
         ::ledcAttachPin(pin, chan_);
     }
-    void analogWrite(uint8_t val) { ::ledcWrite(chan_, val); }
-    uint32_t millis() {return ::millis();}
+    void analogWrite(uint8_t val) const { ::ledcWrite(chan_, val); }
+    uint32_t millis() const {return ::millis();}
 
     uint8_t chan() const { return chan_; }
 

--- a/src/esp8266_hal.h
+++ b/src/esp8266_hal.h
@@ -32,11 +32,11 @@ class Esp8266Hal /*: public AnalogWriter */ {
     explicit Esp8266Hal(uint8_t pin) noexcept : pin_(pin) {
         ::pinMode(pin_, OUTPUT);
     }
-    void analogWrite(uint8_t val) {
+    void analogWrite(uint8_t val) const {
         // ESP8266 uses 10bit PWM range per default, scale value up
         ::analogWrite(pin_, Esp8266Hal::ScaleTo10Bit(val));
     }
-    uint32_t millis() {return ::millis();}
+    uint32_t millis() const {return ::millis();}
 
  protected:
     // scale an 8bit value to 10bit: 0 -> 0, ..., 255 -> 1023,

--- a/src/jled_hal.h
+++ b/src/jled_hal.h
@@ -27,8 +27,8 @@ namespace jled {
 class JLedHal {
  public:
     JLedHal() {}
-    void analogWrite(uint8_t val);
-    uint32_t millis();
+    void analogWrite(uint8_t val) const;
+    uint32_t millis() const;
 };
 }  // namespace jled
 #endif  // SRC_JLED_HAL_H_

--- a/test/test_arduino_hal.cpp
+++ b/test/test_arduino_hal.cpp
@@ -1,15 +1,17 @@
 // JLed Unit tests  (run on host).
 // Copyright 2017 Jan Delgado jdelgado@gmx.net
-#include "catch.hpp"
 #include <arduino_hal.h>  // NOLINT
+#include "catch.hpp"
 
 using jled::ArduinoHal;
 
-TEST_CASE("ctor sets pin mode to OUTPUT", "[arduino_hal]") {
+TEST_CASE("first call to analogWrite() sets pin mode to OUTPUT",
+          "[araduino_hal]") {
     arduinoMockInit();
     constexpr auto kPin = 10;
+    auto h = ArduinoHal(kPin);
     REQUIRE(arduinoMockGetPinMode(kPin) == 0);
-    auto h[[gnu::unused]] = ArduinoHal(kPin);
+    h.analogWrite(123);
     REQUIRE(arduinoMockGetPinMode(kPin) == OUTPUT);
 }
 
@@ -28,4 +30,3 @@ TEST_CASE("millis() returns correct time", "[arduino_hal]") {
     arduinoMockSetMillis(99);
     REQUIRE(h.millis() == 99);
 }
-


### PR DESCRIPTION
STM32 requires pinMode() not to be called in global constructors, but from the setup() function. This MR implements lazy call to pinMode() in the Arduino JLed HAL.
See also https://wiki.stm32duino.com/index.php?title=API#Important_information_about_global_constructor_methods