### PR TITLE
add support for nano33ble using mbed arduino core (#53)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-# use this makefile to build with platformio 
+# use this makefile to build with platformio
 #
 .PHONY: all clean upload monitor lint test ci
 
 # some of the examples use LED_BUILTIN which is not defined for ESP32
-CIOPTS=--board=uno --board=esp01 --lib="src"
+CIOPTS=--board=uno --board=esp01 --board=nano33ble --lib="src"
 CIOPTS_MBED=--board=nucleo_f401re -Oframework=mbed --lib="src"
-CIOPTSALL=--board=esp32dev --board=uno --board=esp01 --lib="src"
+CIOPTSALL=--board=esp32dev --board=uno --board=nano33ble --board=esp01 --lib="src"
 
 all:
 	pio run
@@ -17,15 +17,15 @@ lint:
 ci:
 	platformio ci $(CIOPTS) examples/custom_hal/custom_hal.ino
 	platformio ci $(CIOPTS_MBED) examples/multiled_mbed/multiled_mbed.cpp
-	platformio ci $(CIOPTS) --lib="examples/morse" examples/morse/morse.ino 
+	platformio ci $(CIOPTS) --lib="examples/morse" examples/morse/morse.ino
 	platformio ci $(CIOPTS) examples/candle/candle.ino
-	platformio ci $(CIOPTS) examples/multiled/multiled.ino 
-	platformio ci $(CIOPTS) examples/user_func/user_func.ino 
-	platformio ci $(CIOPTS) examples/hello/hello.ino 
+	platformio ci $(CIOPTS) examples/multiled/multiled.ino
+	platformio ci $(CIOPTS) examples/user_func/user_func.ino
+	platformio ci $(CIOPTS) examples/hello/hello.ino
 	platformio ci $(CIOPTSALL) examples/breathe/breathe.ino
 	platformio ci $(CIOPTS) examples/simple_on/simple_on.ino
 	platformio ci $(CIOPTSALL) examples/fade_on/fade_on.ino
-	platformio ci $(CIOPTSALL) examples/sequence/sequence.ino 
+	platformio ci $(CIOPTSALL) examples/sequence/sequence.ino
 
 envdump:
 	-pio run --target envdump
@@ -35,10 +35,10 @@ clean:
 	rm -f {test,src}/{*.o,*.gcno,*.gcda}
 
 upload:
-	pio run --target upload 
+	pio run --target upload
 
 monitor:
-	pio device monitor 
+	pio device monitor
 
 test:
 	$(MAKE) -C test coverage OPT=-O0

--- a/examples/sequence/sequence.ino
+++ b/examples/sequence/sequence.ino
@@ -3,15 +3,15 @@
 // https://github.com/jandelgado/jled
 #include <jled.h>
 
-constexpr auto PIN_LED = 3;
+constexpr auto LED_PIN = 3;
 
 JLed leds[] = {
-    JLed(PIN_LED).Breathe(2000).Repeat(3),
-    JLed(PIN_LED).Blink(750, 250).Repeat(3),
-    JLed(PIN_LED).FadeOff(1000).Repeat(3),
-    JLed(PIN_LED).Blink(500, 500).Repeat(3),
-    JLed(PIN_LED).FadeOn(1000).Repeat(3),
-    JLed(PIN_LED).Off()
+    JLed(LED_PIN).Breathe(2000).Repeat(3),
+    JLed(LED_PIN).Blink(750, 250).Repeat(3),
+    JLed(LED_PIN).FadeOff(1000).Repeat(3),
+    JLed(LED_PIN).Blink(500, 500).Repeat(3),
+    JLed(LED_PIN).FadeOn(1000).Repeat(3),
+    JLed(LED_PIN).Off()
 };
 
 JLedSequence sequence(JLedSequence::eMode::SEQUENCE, leds);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=JLed
-version=4.5.0
+version=4.5.1
 author=Jan Delgado <jdelgado[at]gmx.net>
 maintainer=Jan Delgado <jdelgado[at]gmx.net>
 sentence=An Arduino library to control LEDs

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,9 +13,11 @@
 ;default_envs = nucleo_f401re_mbed
 ;default_envs = nucleo_f401re
 default_envs = nanoatmega328
+;default_envs = nano33ble
 ;default_envs = nucleo_f401re
 ;default_envs = esp8266
 ;default_envs = esp32
+;default_envs = sparkfun_samd21_dev_usb
 ;default_envs = sparkfun_samd21_dev_usb
 
 ; uncomment example to build
@@ -79,4 +81,11 @@ board = sparkfun_samd21_dev_usb
 build_flags = -Isrc
 src_filter = +<../../src/>  +<./>
 
+[env:nano33ble]
+platform=https://github.com/platformio/platform-nordicnrf52.git
+board = nano33ble
+framework = arduino
+build_flags = -Isrc
+src_filter = +<../../src/>  +<./>
+upload_protocol=stlink
 

--- a/src/jled.h
+++ b/src/jled.h
@@ -35,7 +35,7 @@
 
 #include "jled_base.h"  // NOLINT
 
-#ifdef __MBED__
+#if defined(__MBED__) && !defined(ARDUINO_API_VERSION)
 #include "mbed_hal.h"  // NOLINT
 namespace jled {using JLedHalType = MbedHal;}
 #elif ESP32


### PR DESCRIPTION
The Arduino core for the nano33ble uses mbed and wraps it in the Arduino
core API. Therefore __MBED__ is defined, which makes JLed think it runs
in an Mbed environment. But in this case, JLed needs to use the Arduino
API. The problem is solved by checking also for ARDUINO_API_VERSION:
```
 #if defined(__MBED__) && !defined(ARDUINO_API_VERSION)
```
  -> running in mbed environment
in jled.h.

See
 * https://github.com/arduino/ArduinoCore-API
 * https://github.com/arduino/ArduinoCore-nRF528x-mbedos