### PR TITLE
always use platformio 4.3.4 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - tar xf lcov_1.13.orig.tar.gz
   - make -C lcov-1.13 "PREFIX=${HOME}/.local" install
   - rm -rf lcov-1.13
-  - pip install --user platformio
+  - pip install --user platformio==4.3.4
   - gem install coveralls-lcov
   - mkdir -p ~/.local/bin
   - wget -O ~/.local/bin/cpplint "$CPP_LINT_URL" && chmod 755 ~/.local/bin/cpplint


### PR DESCRIPTION
... because version 5.x, which is used by default when doing `pip install` is causing problems at the moment

```
$ make ci

platformio ci --board=uno --board=esp01 --board=nano33ble --lib="src" examples/custom_hal/custom_hal.ino

Error: HTTPSConnectionPool(host='api.registry.ns1.platformio.org', port=443): Max retries exceeded with url: /v2/boards (Caused by SSLError(CertificateError("hostname 'api.registry.ns1.platformio.org' doesn't match either of '*.platformio.org', 'platformio.org'",),))

make: *** [ci] Error 1
```