### PR TITLE
ESP32: fix glimming LED problem (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # JLed changelog
 
+## [2020-10-24] 4.5.2
+
+* fix: ESP32 led glimming when using low-active connection (#60)
+
+## [2020-07-01] 4.5.1
+
+* fix: support for Nano 33 BLE (#53)
+
 ## [2020-02-23] 4.5.0
 
 * new: `JLed::MaxBrightness(uint8_t level)` method to limit output of effects

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=JLed
-version=4.5.1
+version=4.5.2
 author=Jan Delgado <jdelgado[at]gmx.net>
 maintainer=Jan Delgado <jdelgado[at]gmx.net>
 sentence=An Arduino library to control LEDs

--- a/src/esp32_hal.h
+++ b/src/esp32_hal.h
@@ -1,5 +1,7 @@
-// Copyright (c) 2017 Jan Delgado <jdelgado[at]gmx.net>
+// Copyright (c) 2017-2020 Jan Delgado <jdelgado[at]gmx.net>
 // https://github.com/jandelgado/jled
+// HAL for the ESP32
+// https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/ledc.html
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
@@ -84,7 +86,9 @@ class Esp32Hal {
         ::ledcSetup(chan_, freq, kLedcTimer8Bit);
         ::ledcAttachPin(pin, chan_);
     }
-    void analogWrite(uint8_t val) const { ::ledcWrite(chan_, val); }
+    void analogWrite(uint8_t val) const {
+        ::ledcWrite(chan_, (val == 255)? 256 : val);
+    }
     uint32_t millis() const { return ::millis(); }
 
     PinType chan() const { return chan_; }


### PR DESCRIPTION
on ESP32 with LEDs connected as low-active.

Needs value of 256 to turn LED off, 255 keeps the LED glimming.

See https://github.com/espressif/arduino-esp32/issues/689
