### PR TITLE
Repeat() and Forever() for sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-# JLed changelog
+# JLed changelog (github.com/jandelgado/jled)
 
-## [tbd] 4.5.3
+## [2021-01-24] 4.6.0
 
+* new: JLedSequence can be configured to play the sequence multiple times
+       using the `Repeat()` and `Forever()` methods
 * drop travis-ci, use github actions
 
 ## [2020-10-24] 4.5.2

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ an effect. The default value is 0 ms.
 
 ##### Repetitions
 
-Use the `Repeat()` method to specify the number of repetition. The default
+Use the `Repeat()` method to specify the number of repetitions. The default
 value is 1 repetition. The `Forever()` methods sets to repeat the effect
 forever. Each repetition includes a full period of the effect and the time
 specified by `DelayAfter()` method.
@@ -382,11 +382,11 @@ effect when the previous finished. The constructor takes the mode (`PARALLEL`,
 
 ```c++
 JLed leds[] = {
-    JLed(4).Blink(750, 250).Forever(),
-    JLed(3).Breathe(2000).Forever()
+    JLed(4).Blink(750, 250).Repeat(10),
+    JLed(3).Breathe(2000).Repeat(5);
 };
 
-JLedSequence sequence(JLedSequence::eMode::PARALLEL, leds);
+auto sequence = JLedSequence(JLedSequence::eMode::PARALLEL, leds).Repeat(2);
 
 void setup() {
 }
@@ -405,6 +405,9 @@ The `JLedSequence` provides the following methods:
 * `Update()` - updates the active `JLed` objects controlled by the sequence.
   Like the `JLed::Update()` method, it returns `true` if an effect is running,
   else `false`.
+* Use the `Repeat(n)` method to specify the number of repetitions. The default
+  value is 1 repetition. The `Forever()` methods sets to repeat the sequence
+  forever. 
 * `Stop()` - turns off all `JLed` objects controlled by the sequence and 
    stops the sequence. Further calls to `Update()` will have no effect.
 * `Reset()` - Resets all `JLed` objects controlled by the sequence and 

--- a/examples/multiled/multiled.ino
+++ b/examples/multiled/multiled.ino
@@ -1,17 +1,17 @@
 // JLed multi LED demo. control multiple LEDs in-sync.
-// Copyright 2017 by Jan Delgado. All rights reserved.
+// Copyright (c) 2017-2021 by Jan Delgado. All rights reserved.
 // https://github.com/jandelgado/jled
 #include <jled.h>
 
 JLed leds[] = {
-    JLed(4).Blink(750, 250).Forever(),
-    JLed(3).Breathe(2000).Forever(),
-    JLed(5).FadeOff(1000).Forever(),
-    JLed(6).FadeOn(1000).Forever(),
-    JLed(LED_BUILTIN).Blink(500, 500).Forever()
+    JLed(4).Blink(750, 250).Repeat(2),
+    JLed(3).Breathe(2000),
+    JLed(5).FadeOff(1000).Repeat(2),
+    JLed(6).FadeOn(1000).Repeat(2),
+    JLed(LED_BUILTIN).Blink(500, 500).Repeat(2)
 };
 
-JLedSequence sequence(JLedSequence::eMode::PARALLEL, leds);
+auto sequence = JLedSequence(JLedSequence::eMode::PARALLEL, leds).Repeat(5);
 
 void setup() { }
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=JLed
-version=4.5.2
+version=4.6.0
 author=Jan Delgado <jdelgado[at]gmx.net>
 maintainer=Jan Delgado <jdelgado[at]gmx.net>
 sentence=An Arduino library to control LEDs


### PR DESCRIPTION
Provide  `Repeat()` and `Forever()` methods on the `JLedSequence` class
Implements #65 and #39
