### PR TITLE
allow pointer types in TJLedSequence

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: install tools
       run: |
-        pip install platformio==5.0.3
+        pip install platformio==5.1.1
         sudo apt-get update && sudo apt-get install -y lcov
 
     - name: run tests
@@ -54,4 +54,3 @@ jobs:
 
     - name: build examples
       run: make ci
-

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,6 +58,7 @@ framework = arduino
 build_flags = -Isrc
 src_filter = +<../../src/>  +<./>
 upload_protocol=stlink
+debug_speed=auto
 
 [env:esp8266]
 platform = espressif8266

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -448,6 +448,9 @@ class TJLed {
     uint16_t delay_after_ = 0;   // delay after each repetition
 };
 
+template<typename T> T* ptr(T &obj) {return &obj;}  // NOLINT
+template<typename T> T* ptr(T *obj) {return obj;}
+
 // a group of JLed objects which can be controlled simultanously, in parallel
 // or sequentially.
 template <typename T>
@@ -458,7 +461,7 @@ class TJLedSequence {
     bool UpdateParallel() {
         auto result = false;
         for (auto i = 0u; i < n_; i++) {
-            result |= leds_[i].Update();
+            result |= ptr(leds_[i])->Update();
         }
         return result;
     }
@@ -469,7 +472,7 @@ class TJLedSequence {
         if (cur_ >= n_) {
             return false;
         }
-        if (!leds_[cur_].Update()) {
+        if (!ptr(leds_[cur_])->Update()) {
             return ++cur_ < n_;
         }
         return true;;
@@ -477,7 +480,7 @@ class TJLedSequence {
 
     void ResetLeds() {
         for (auto i = 0u; i < n_; i++) {
-            leds_[i].Reset();
+            ptr(leds_[i])->Reset();
         }
     }
 


### PR DESCRIPTION
This change is needed for the MicroPython port in order to operate also on
an array of JLed* pointers, when the JLedSequence class is defined as
TJLedSequence<JLed*>.