### PR TITLE
Make breathe function more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ void loop() {
 }
 ```
 
+It is also possible to specify fade-on, on and fade-off durations for the breathing mode to customize the effect.
+
+```c++
+// LED will fade-on in 500ms, stay on for 1000ms, and fade-off in 500ms.
+// It will delay for 1000ms afterwards and continue the pattern.
+auto led = JLed(13).Breathe(500, 1000, 500).DelayAfter(1000).Forever();
+```
+
 #### Candle
 
 In candle mode, the random flickering of a candle or fire is simulated. 

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -216,7 +216,7 @@ TEST_CASE(
     "BreatheEvaluator evaluates to bell curve distributed brightness curve",
     "[jled]") {
     constexpr auto kPeriod = 2000;
-    auto eval = BreatheBrightnessEvaluator(kPeriod);
+    auto eval = BreatheBrightnessEvaluator(kPeriod / 2, 0, kPeriod / 2);
     REQUIRE(kPeriod == eval.Period());
     const std::map<uint32_t, uint8_t> test_values = {
         {0, 0}, {500, 68}, {1000, 255}, {1500, 68}, {1999, 0}, {2000, 0}};


### PR DESCRIPTION
Thanks for the great library! Here is a change I find useful:

Instead of just a period argument, breathe function now accepts fade-on, on and fade-off durations for more a more flexible breathe animation.

As this causes a breaking change, we could add this as a separate function instead. Open for suggestions.