### PR TITLE
Handle millis overflow during running state

### DIFF
--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -375,7 +375,7 @@ class TJLed {
         }
         last_update_time_ = now;
 
-        if (now < time_start_) return true;
+        if (now >= last_update_time_ && now < time_start_) return true;
 
         // t cycles in range [0..period+delay_after-1]
         const auto period = brightness_eval_->Period();


### PR DESCRIPTION
If millis overflowed during running state, `now < time_start_` always returned true and hanged the library. This change checks if `now >= last_update_time_` to ensure there is no overflow situation.