### PR TITLE
Allow to trigger callback after an effect is finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # JLed changelog (github.com/jandelgado/jled)
 
+## [2021-12-12] 4.10.0
+
+* new: `JLed::UpdateAndFinally` method allowing to trigger custom code after
+       an effect is finished. See [README.md#updateandfinally] for details.
+       
 ## [2022-02-24] 4.9.1
 
 * fix: make sure JLedSequence methods like `Repeat` and `Forever` are chainable
@@ -12,11 +17,6 @@
        https://github.com/jandelgado/jled-esp-idf-example and
        https://github.com/jandelgado/jled-esp-idf-platformio-example
        
-## [2021-12-12] 4.9.0
-
-* new: `JLed::UpdateAndFinally` method allowing to trigger custom code after
-       an effect is finished. See [README.md#updateandfinally] for details.
-
 ## [2021-10-18] 4.8.0
 
 * new: make `Breathe` method more flexible (#78, thanks to @boraozgen)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
        https://github.com/jandelgado/jled-esp-idf-example and
        https://github.com/jandelgado/jled-esp-idf-platformio-example
        
+## [2021-12-12] 4.9.0
+
+* new: `JLed::UpdateAndFinally` method allowing to trigger custom code after
+       an effect is finished. See [README.md#updateandfinally] for details.
+
 ## [2021-10-18] 4.8.0
 
 * new: make `Breathe` method more flexible (#78, thanks to @boraozgen)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ void loop() {
             * [Repetitions](#repetitions)
         * [State functions](#state-functions)
             * [Update](#update)
+            * [UpdateAndFinally](#updateandfinally)
             * [IsRunning](#isrunning)
             * [Reset](#reset)
             * [Immediate Stop](#immediate-stop)
@@ -356,6 +357,32 @@ specified by `DelayAfter()` method.
 
 Call `Update()` periodically to update the state of the LED. `Update` returns
 `true` if the effect is active, and `false` when it finished.
+
+##### UpdateAndFinally
+
+`UpdateAndFinally` first calls `Update`, and if the effect is finished, the
+provided callback function is called once. This allows for e.g. reconfiguration
+of an effect, when the effect is finished.  The callback function can be either
+be specified as a lambda `[] (JLed&, void*) { /* code */ }` or as a function
+with a definition like `void callback(JLed&, void*)`.  The callback function
+gets a reference to the `JLed` object as well as a `void*` pointer, for
+additional optional user specified data, passed. Note that we can not use
+full-fledged lambda functions here because the `<funtional>` header is not
+available available for the AVR platform. Example:
+
+```c++
+  led.UpdateAndFinally(
+          [] (JLed& led, void*) {
+            const auto d = random(50,5000);
+            led.Breathe(d);
+            led.Reset();
+    }
+  );
+
+```
+
+The example uses a lambda function to set a new random duration for the breate
+effect and restarts the effect by calling `Reset()`.
 
 ##### IsRunning
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "JLed",
-    "version": "4.9.1",
+    "version": "4.10.0",
     "description": "An embedded library to control LEDs",
     "license": "MIT",
     "frameworks": ["espidf", "arduino", "mbed"],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=JLed
-version=4.9.1
+version=4.10.0
 author=Jan Delgado <jdelgado[at]gmx.net>
 maintainer=Jan Delgado <jdelgado[at]gmx.net>
 sentence=An Arduino library to control LEDs

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -254,12 +254,12 @@ class TJLed {
     // functional header is not available for AVR. That means we can only use
     // lambdas without captures. As a workaround, we allow an additional void*
     // pointer to be passed, which can point to arbitrary data.
-    typedef void (*FinallyCallback)(B& led, void* data);
+    typedef void (*FinallyCallback)(B& led, void* data);    // NOLINT
 
     // Call Update and when the effect is finished, call the provided function
     // f, which gets a reference to this JLed object and an optional data
     // pointer.  Use e.g. to reconfigure & restart after an effect was played.
-    bool UpdateAndFinally(FinallyCallback f, void* data=nullptr) {
+    bool UpdateAndFinally(FinallyCallback f, void* data = nullptr) {
         if (!IsRunning()) {
             return false;
         }

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -213,12 +213,14 @@ TEST_CASE("FadeOffEvaluator evaluates to expected brightness curve", "[jled]") {
 }
 
 TEST_CASE(
-    "BreatheEvaluator evaluates to flattened bell curve distributed brightness curve",
+    "BreatheEvaluator evaluates to flattened bell curve distributed brightness "
+    "curve",
     "[jled]") {
     const auto eval = BreatheBrightnessEvaluator(1000, 2000, 500);
-    REQUIRE(1000+2000+500 == eval.Period());
+    REQUIRE(1000 + 2000 + 500 == eval.Period());
     const std::map<uint32_t, uint8_t> test_values = {
-        {0, 0}, {500, 68}, {1000, 255}, {2000, 255}, {3000, 255}, {3250, 68}, {3499, 0}, {3500, 0}};
+        {0, 0},      {500, 68},  {1000, 255}, {2000, 255},
+        {3000, 255}, {3250, 68}, {3499, 0},   {3500, 0}};
 
     for (const auto &x : test_values) {
         REQUIRE((int)x.second == (int)eval.Eval(x.first));
@@ -393,26 +395,28 @@ TEST_CASE("Update returns true while updating, else false", "[jled]") {
     REQUIRE_FALSE(jled.Update());
 }
 
-TEST_CASE("UpdateAndFinally triggers the callback once on the last iteration", "[jled]") {
+TEST_CASE("UpdateAndFinally triggers the callback once on the last iteration",
+          "[jled]") {
     TestJLed jled = TestJLed(10).Blink(1, 1);
 
     int cbCalled = 0;
-    auto cb = [] (TestJLed&, void* p) {
+    auto cb = [](TestJLed &, void *p) {
         // gets &cbCalled passed in as void* p
-        (*(int*)p)++;
+        int *pCbCalled = (static_cast<int*>(p));
+        (*pCbCalled)++;
     };
 
     jled.Hal().SetMillis(0);
     REQUIRE(jled.UpdateAndFinally(cb, &cbCalled));
-    REQUIRE( cbCalled == 0 );
+    REQUIRE(cbCalled == 0);
 
     jled.Hal().SetMillis(1);
     REQUIRE(!jled.UpdateAndFinally(cb, &cbCalled));
-    REQUIRE( cbCalled == 1 );
+    REQUIRE(cbCalled == 1);
 
     jled.Hal().SetMillis(2);
     REQUIRE(!jled.UpdateAndFinally(cb, &cbCalled));
-    REQUIRE( cbCalled == 1 );
+    REQUIRE(cbCalled == 1);
 }
 
 TEST_CASE("After Reset() the effect can be restarted", "[jled]") {
@@ -562,4 +566,3 @@ TEST_CASE("scaling a value with factor 31 returns original value", "[scale5]") {
     REQUIRE(127 == jled::scale5(127, 31));
     REQUIRE(255 == jled::scale5(255, 31));
 }
-


### PR DESCRIPTION
#82 inspired this MR:
Added a new `UpdateAndFinally` method that will update the effect like `Update` but will trigger the provided callback when the effect is finished. This allows e.g. reconfiguration of an effect.

Example:
```c++
#include <jled.h>

auto breathe = JLed(2).Breathe(500);

void setup() { }

void loop()  {
  breathe.UpdateAndFinally(
          [] (JLed& led, void*) {
            led.Breathe(random(50,5000));
            led.Reset();
    }
  );
}
```