### PR TITLE
ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-# this CMakeLists.txt file is needed to include JLed in raspi pico projects
-add_library (JLed src/jled_base.cpp)
-target_include_directories (JLed PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-
+if(IDF_VER) # ESP-IDF component
+	idf_component_register(SRC_DIRS "src"  INCLUDE_DIRS "src")
+	target_compile_options(${COMPONENT_LIB} PUBLIC -DESP32)
+else() # Raspberry Pi Pico
+	add_library (JLed src/jled_base.cpp)
+	target_include_directories (JLed PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+endif()


### PR DESCRIPTION
Removed Arduino.h dependency and used native functions so this lib can be used as native ESP-IDF component.
CMakeLists.txt changed accordingly.