### PR TITLE
Fix sequence methods not chainable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # JLed changelog (github.com/jandelgado/jled)
 
+## [2022-02-24] 4.9.1
+
+* fix: make sure JLedSequence methods like `Repeat` and `Forever` are chainable
+  like in the `JLed` class
+
 ## [2022-02-13] 4.9.0
 
 * new: support ESP-IDF platform for the ESP32 (#87, thanks to @troky for the

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "JLed",
-    "version": "4.9.0",
+    "version": "4.9.1",
     "description": "An embedded library to control LEDs",
     "license": "MIT",
     "frameworks": ["espidf", "arduino", "mbed"],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=JLed
-version=4.9.0
+version=4.9.1
 author=Jan Delgado <jdelgado[at]gmx.net>
 maintainer=Jan Delgado <jdelgado[at]gmx.net>
 sentence=An Arduino library to control LEDs

--- a/src/jled.h
+++ b/src/jled.h
@@ -58,8 +58,8 @@ class JLed : public TJLed<JLedHalType, JLed> {
 };
 
 // a group of JLed objects which can be controlled simultanously
-class JLedSequence : public TJLedSequence<JLed> {
-    using TJLedSequence<JLed>::TJLedSequence;
+class JLedSequence : public TJLedSequence<JLed, JLedSequence> {
+    using TJLedSequence<JLed, JLedSequence>::TJLedSequence;
 };
 
 };  // namespace jled

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -472,7 +472,7 @@ template<typename T> T* ptr(T *obj) {return obj;}
 
 // a group of JLed objects which can be controlled simultanously, in parallel
 // or sequentially.
-template <typename T>
+template <typename L, typename B>
 class TJLedSequence {
  protected:
     // update all leds parallel. Returns true while any of the JLeds is
@@ -509,9 +509,9 @@ class TJLedSequence {
     TJLedSequence() = delete;
 
     template <size_t N>
-    TJLedSequence(eMode mode, T (&leds)[N]) : TJLedSequence(mode, leds, N) {}
+    TJLedSequence(eMode mode, L (&leds)[N]) : TJLedSequence(mode, leds, N) {}
 
-    TJLedSequence(eMode mode, T* leds, size_t n)
+    TJLedSequence(eMode mode, L* leds, size_t n)
         : mode_{mode}, leds_{leds}, cur_{0}, n_{n} {}
 
     bool Update() {
@@ -549,18 +549,18 @@ class TJLedSequence {
     }
 
     // set number of repetitions for the sequence
-    TJLedSequence<T> Repeat(uint16_t num_repetitions) {
+    B& Repeat(uint16_t num_repetitions) {
         num_repetitions_ = num_repetitions;
-        return *this;
+        return static_cast<B&>(*this);
     }
 
     // repeat Forever
-    TJLedSequence<T> Forever() { return Repeat(kRepeatForever); }
+    B& Forever() { return Repeat(kRepeatForever); }
     bool IsForever() const { return num_repetitions_ == kRepeatForever; }
 
  private:
     const eMode mode_;
-    T* leds_;
+    L* leds_;
     size_t cur_;
     const size_t n_;
     static constexpr uint16_t kRepeatForever = 65535;

--- a/test/test_jled_sequence.cpp
+++ b/test/test_jled_sequence.cpp
@@ -15,13 +15,13 @@ class TestJLed : public TJLed<HalMock, TestJLed> {
 };
 
 // a group of JLed objects which can be controlled simultanously
-class TestJLedSequence : public TJLedSequence<TestJLed> {
-    using TJLedSequence<TestJLed>::TJLedSequence;
+class TestJLedSequence : public TJLedSequence<TestJLed, TestJLedSequence> {
+    using TJLedSequence<TestJLed, TestJLedSequence>::TJLedSequence;
 };
 
 // instanciate for test coverage measurement
 template class TJLed<HalMock, TestJLed>;
-template class TJLedSequence<TestJLed>;
+template class TJLedSequence<TestJLed, TestJLedSequence>;
 
 TEST_CASE("parallel sequence performs all updates", "[jled_sequence]") {
     constexpr uint8_t expected1[] = {255, 0, 0};
@@ -153,6 +153,15 @@ TEST_CASE("Forever flag is set by call to Forever()", "[jled_sequence]") {
         auto seq = TestJLedSequence(mode, leds).Forever();
         REQUIRE(seq.IsForever());
     }
+}
+
+TEST_CASE("Forever and Repeat calls can be chained", "[jled_sequence]") {
+    // this is a compile time check only
+    TestJLed leds[] = {TestJLed(0)};
+    TestJLedSequence hal[[gnu::unused]] =
+        TestJLedSequence(TestJLedSequence::eMode::PARALLEL, leds)
+            .Repeat(1)
+            .Forever();
 }
 
 TEST_CASE("reset on sequence resets all JLeds", "[jled_sequence]") {


### PR DESCRIPTION
This fixes that currently we can not chain method calls in the `JLedSequence` class like we do in the `JLed` class

```c++
auto seq = JLedSequence(...).Forever();
                             ^^^^^^^^^^
```
