### PR TITLE
Add period to on and off effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JLed changelog (github.com/jandelgado/jled)
 
+## [2022-02-24] 4.10.0
+
+* new: `On`, `Off` and `Set` now take an optional `duration` value, making
+       these effects behave like any other in this regard. This allows to add 
+       an `On` effect to a `JLedSequence` for a specific amount of time.
+
 ## [2022-02-24] 4.9.1
 
 * fix: make sure JLedSequence methods like `Repeat` and `Forever` are chainable

--- a/README.md
+++ b/README.md
@@ -155,18 +155,22 @@ See the examples section below for further details.
 
 #### Static on and off
 
-Calling `On()` turns the LED on.  To immediately turn a LED on, make a call
-like `JLed(LED_BUILTIN).On().Update()`.
+Calling `On(uint16_t period=1)` turns the LED on. To immediately turn a LED on,
+make a call like `JLed(LED_BUILTIN).On().Update()`. The `period` is optional
+and defaults to 1ms.
 
 `Off()` works like `On()`, except that it turns the LED off, i.e. it sets the
 brightness to 0.
 
-Use the `Set(uint8_t brightness)` method to set the brightness to the given
-value, i.e. `Set(255)` is equivalent to calling `On()` and `Set(0)` is
-equivalent to calling `Off()`.
+Use the `Set(uint8_t brightness, uint16_t period=1)` method to set the
+brightness to the given value, i.e. `Set(255)` is equivalent to calling `On()`
+and `Set(0)` is equivalent to calling `Off()`.
 
-Technically `Set`,  `On` and `Off` are effects with a period of 1ms that 
-set the brightness to a constant value.
+Technically, `Set`, `On` and `Off` are effects with a default period of 1ms, that 
+set the brightness to a constant value. Specifiying a different period has an
+effect on when the `Update()` method will be done updating the effect and 
+return false (like for any other effects). This is important when for example
+in a `JLedSequence` the LED should stay on for a given amount of time.
 
 ##### Static on example
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "JLed",
-    "version": "4.9.1",
+    "version": "4.10.0",
     "description": "An embedded library to control LEDs",
     "license": "MIT",
     "frameworks": ["espidf", "arduino", "mbed"],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=JLed
-version=4.9.1
+version=4.10.0
 author=Jan Delgado <jdelgado[at]gmx.net>
 maintainer=Jan Delgado <jdelgado[at]gmx.net>
 sentence=An Arduino library to control LEDs


### PR DESCRIPTION
 `On`, `Off` and `Set` now take an optional `duration` value, making these effects behave like any other in this regard. This allows to add an `On` effect to a `JLedSequence` for a specific amount of time.