### PR TITLE
Make JLedSequence objects assignable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # JLed changelog (github.com/jandelgado/jled)
 
-## [2022-02-24] 4.10.0
+## [2022-03-29] 4.11.0
+
+* change: `JLedSequence` objects are now assignable, making switching 
+  effects easier. See https://github.com/jandelgado/jled-example-switch-sequence for an example.
+  
+## [2022-03-24] 4.10.0
 
 * new: `On`, `Off` and `Set` now take an optional `duration` value, making
        these effects behave like any other in this regard. This allows to add 

--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ Example sketches are provided in the [examples](examples/) directory.
 * [Simple User provided effect](examples/user_func)
 * [Morsecode example](examples/morse)
 * [Custom HAL example](examples/custom_hal)
+* [Dynamically switch sequences](https://github.com/jandelgado/jled-example-switch-sequence)
 * [JLed compiled to WASM and running in the browser](https://jandelgado.github.io/jled-wasm)
 * [Raspberry Pi Pico Demo](examples/raspi_pico)
 * [ESP32 ESP-IDF example](https://github.com/jandelgado/jled-esp-idf-example)

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "JLed",
-    "version": "4.10.0",
+    "version": "4.11.0",
     "description": "An embedded library to control LEDs",
     "license": "MIT",
     "frameworks": ["espidf", "arduino", "mbed"],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=JLed
-version=4.10.0
+version=4.11.0
 author=Jan Delgado <jdelgado[at]gmx.net>
 maintainer=Jan Delgado <jdelgado[at]gmx.net>
 sentence=An Arduino library to control LEDs

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -580,5 +580,4 @@ class TJLedSequence {
 };
 
 };  // namespace jled
-
 #endif  // SRC_JLED_BASE_H_

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -569,10 +569,10 @@ class TJLedSequence {
     bool IsForever() const { return num_repetitions_ == kRepeatForever; }
 
  private:
-    const eMode mode_;
+    eMode mode_;
     L* leds_;
     size_t cur_;
-    const size_t n_;
+    size_t n_;
     static constexpr uint16_t kRepeatForever = 65535;
     uint16_t num_repetitions_ = 1;
     uint16_t iteration_ = 0;


### PR DESCRIPTION
make sure a JLedSequence object can be re-assigned, to change sequences at runtime
See https://github.com/jandelgado/jled-example-switch-sequence for an example