### PR TITLE
add: pause and resume

### DIFF
--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -361,6 +361,21 @@ class TJLed {
         return static_cast<B&>(*this);
     }
 
+    // Pause effect until Resume is called with the value here returned
+    // TODO(jd) second optional parameter to control end state of LED
+    uint32_t Pause() {
+        // TODO(jd) only if state is running
+        state_ = ST_STOPPED;
+        return hal_.millis() - time_start_;
+    }
+
+    B& Resume(uint32_t delta) {
+        // TODO(jd) only if state is stopped
+        state_ = ST_RUNNING;
+        time_start_ = hal_.millis() - delta;
+        return static_cast<B&>(*this);
+    }
+
     // Sets the maximum brightness level. 255 is full brightness, 0 turns the
     // effect off. Currently, only upper 5 bits of the provided value are used
     // and stored.
@@ -470,7 +485,7 @@ class TJLed {
 };
 
 template <typename T>
-T* ptr(T& obj) {    // NOLINT
+T* ptr(T& obj) {  // NOLINT
     return &obj;
 }
 template <typename T>
@@ -574,5 +589,5 @@ class TJLedSequence {
     bool is_running_ = true;
 };
 
-};  // namespace jled
+};      // namespace jled
 #endif  // SRC_JLED_BASE_H_

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -455,20 +455,6 @@ TEST_CASE("Pause stops further update of effect", "[jled]") {
     REQUIRE(false == jled.Update());
 }
 
-TEST_CASE("Pause returns time effect run so far", "[jled]") {
-    auto eval = MockBrightnessEvaluator(ByteVec{10, 20, 30, 40});
-    TestJLed jled = TestJLed(10).UserFunc(&eval);
-
-    // start at t=1000
-    jled.Hal().SetMillis(1000);
-    jled.Update();
-
-    // pause at t=1100
-    jled.Hal().SetMillis(1100);
-    auto d = jled.Pause();
-    REQUIRE(100 == d);
-}
-
 TEST_CASE("Resume after Pause continues later where we left off", "[jled]") {
     auto eval = MockBrightnessEvaluator(ByteVec{10, 20, 30});
     TestJLed jled = TestJLed(10).UserFunc(&eval);
@@ -479,12 +465,14 @@ TEST_CASE("Resume after Pause continues later where we left off", "[jled]") {
 
     // pause at t=1001
     jled.Hal().SetMillis(1001);
-    auto d = jled.Pause();
+    auto state = jled.Pause();
 
-    // resume at t=2000, we expectd to continue where we left off
+    REQUIRE_FALSE(jled.IsRunning());
+
+    // resume at t=2000, we expect to continue where we left off
     // at t=1001
     jled.Hal().SetMillis(2000);
-    jled.Resume(d);
+    jled.Resume(state);
 
     REQUIRE(true == jled.Update());
     REQUIRE(20 == jled.Hal().Value());


### PR DESCRIPTION
call `Pause` to pause the effect. A later call of `Resume` continues where `Pause` left off. Usage:

```c++
auto state = led.Pause()
// ... and later on
led.Resume(state)
```