### PR TITLE
Allow stop to turn led fully off regardless of min brightness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # JLed changelog (github.com/jandelgado/jled)
 
+## [2023-08-20] 4.13.0
+
+* new: `Stop()` takes optional parameter allowing to turn LED fully off
+
 ## [2023-06-29] 4.12.2
 
 * fix: `JLedSequence` starting again after call to `Stop` (https://github.com/jandelgado/jled/issues/115)

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ See the examples section below for further details.
 First the configured effect (e.g. `Fade`) is evaluated for the current time
 `t`. JLed internally uses unsigned bytes to represent brightness values,
 ranging from 0 to 255. Next, the value is scaled to the limits set by
-`MinBrightness` and `MaxBrightness` (otionally). When the effect is configured
+`MinBrightness` and `MaxBrightness` (optionally). When the effect is configured
 for an low-active LED using `LowActive`, the brightness value will be inverted,
 i.e. the value will be subtracted from 255. Finally the value is passed to the
 hardware abstraction, which might scale it to the resolution used by the actual

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ First the configured effect (e.g. `Fade`) is evaluated for the current time
 `t`. JLed internally uses unsigned bytes to represent brightness values,
 ranging from 0 to 255. Next, the value is scaled to the limits set by
 `MinBrightness` and `MaxBrightness` (optionally). When the effect is configured
-for an low-active LED using `LowActive`, the brightness value will be inverted,
-i.e. the value will be subtracted from 255. Finally the value is passed to the
+for a low-active LED using `LowActive`, the brightness value will be inverted,
+i.e., the value will be subtracted from 255. Finally the value is passed to the
 hardware abstraction, which might scale it to the resolution used by the actual
 device (e.g. 10 bits for an ESP8266). Finally the brightness value is written
 out to the configure GPIO.
@@ -187,15 +187,15 @@ Calling `On(uint16_t period=1)` turns the LED on. To immediately turn a LED on,
 make a call like `JLed(LED_BUILTIN).On().Update()`. The `period` is optional
 and defaults to 1ms.
 
-`Off()` works like `On()`, except that it turns the LED off, i.e. it sets the
+`Off()` works like `On()`, except that it turns the LED off, i.e., it sets the
 brightness to 0.
 
 Use the `Set(uint8_t brightness, uint16_t period=1)` method to set the
-brightness to the given value, i.e. `Set(255)` is equivalent to calling `On()`
+brightness to the given value, i.e., `Set(255)` is equivalent to calling `On()`
 and `Set(0)` is equivalent to calling `Off()`.
 
 Technically, `Set`, `On` and `Off` are effects with a default period of 1ms, that 
-set the brightness to a constant value. Specifiying a different period has an
+set the brightness to a constant value. Specifying a different period has an
 effect on when the `Update()` method will be done updating the effect and 
 return false (like for any other effects). This is important when for example
 in a `JLedSequence` the LED should stay on for a given amount of time.
@@ -325,7 +325,7 @@ void loop() {
 
 In FadeOff mode, the LED is smoothly faded off using PWM. The fade starts at
 100% brightness. Internally it is implemented as a mirrored version of the
-FadeOn function, i.e. FadeOff(t) = FadeOn(period-t).  The `FadeOff()` method
+FadeOn function, i.e., FadeOff(t) = FadeOn(period-t).  The `FadeOff()` method
 takes the period of the effect as argument.
 
 #### Fade
@@ -333,7 +333,7 @@ takes the period of the effect as argument.
 The Fade effect allows to fade from any start value `from` to any target value
 `to` with the given duration. Internally it sets up a `FadeOn` or `FadeOff`
 effect and `MinBrightness` and `MaxBrightness` values properly. The `Fade`
-method take three argumens: `from`, `to` and `duration`.
+method take three arguments: `from`, `to` and `duration`.
 
 <a href="examples/fade_from_to"><img alt="fade from-to" src="doc/fade_from-to.png" height=200></a>
 
@@ -425,22 +425,29 @@ you want to start-over an effect.
 ##### Immediate Stop
 
 Call `Stop()` to immediately turn the LED off and stop any running effects.
-Further calls to `Update()` will have no effect unless the Led is reset (using
-`Reset()`) or a new effect is activated. `Stop()` set the current brightness level
-to 0, and applies the `MinBrightness` and `MaxBrightness` settings.
+Further calls to `Update()` will have no effect, unless the Led is reset using
+`Reset()` or a new effect is activated. By default, `Stop()` sets the current
+brightness level to `MinBrightness`.
 
-`Stop()` takes an optional argument `mode` of type `JLed::eStopMode` that can
-be set to `JLed::eStopMode::ABS_ZERO` to force the LEDs level to be `0`,
-regardless of what `MinBrightness` is set to, e.g. call it like
-`Stop(JLed::eStopMode::ABS_ZERO)`. When passing `JLed::eStopMode::KEEP`, the
-LEDs current level will be kept.
+`Stop()` takes an optional argument `mode` of type `JLed::eStopMode`:
+
+* if set to `JLed::eStopMode::KEEP_CURRENT`, the LEDs current level will be kept
+* if set to `JLed::eStopMode::FULL_OFF` the level of the LED is set to `0`,
+  regardless of what `MinBrightness` is set to, effectively turning the LED off
+* if set to `JLed::eStopMode::TO_MIN_BRIGHTNESS` (default behavior), the LED
+  will set to the value of `MinBrightness`
+
+```c++
+// stop the effect and set the brightness level to 0, regardless of min brightness
+led.Stop(JLed::eStopMode::FULL_OFF);
+```
 
 #### Misc functions
 
 ##### Low active for inverted output
 
 Use the `LowActive()` method when the connected LED is low active. All output
-will be inverted by JLed (i.e. instead of x, the value of 255-x will be set).
+will be inverted by JLed (i.e., instead of x, the value of 255-x will be set).
 
 ##### Minimum- and Maximum brightness level
 
@@ -531,7 +538,7 @@ src_dir = examples/multiled_mbed
 
 The DAC of the ESP8266 operates with 10 bits, every value JLed writes out gets
 automatically scaled to 10 bits, since JLed internally only uses 8 bits.  The
-scaling methods make sure that min/max relationships are preserved, i.e. 0 is
+scaling methods make sure that min/max relationships are preserved, i.e., 0 is
 mapped to 0 and 255 is mapped to 1023. When using a user-defined brightness
 function on the ESP8266, 8-bit values must be returned, all scaling is done by
 JLed transparently for the application, yielding platform-independent code.

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "JLed",
-    "version": "4.12.2",
+    "version": "4.13.0",
     "description": "An embedded library to control LEDs",
     "license": "MIT",
     "frameworks": ["espidf", "arduino", "mbed"],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=JLed
-version=4.12.2
+version=4.13.0
 author=Jan Delgado <jdelgado[at]gmx.net>
 maintainer=Jan Delgado <jdelgado[at]gmx.net>
 sentence=An Arduino library to control LEDs

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -340,10 +340,10 @@ class TJLed {
 
     // Stop current effect and turn LED immeadiately off. Further calls to
     // Update() will have no effect.
-    enum eStopMode { ABS_ZERO, REL_ZERO, KEEP };
-    B& Stop(eStopMode mode = eStopMode::REL_ZERO) {
-        if (mode != eStopMode::KEEP) {
-            Write(mode == eStopMode::ABS_ZERO ? kZeroBrightness
+    enum eStopMode { TO_MIN_BRIGHTNESS = 0, FULL_OFF, KEEP_CURRENT };
+    B& Stop(eStopMode mode = eStopMode::TO_MIN_BRIGHTNESS) {
+        if (mode != eStopMode::KEEP_CURRENT) {
+            Write(mode == eStopMode::FULL_OFF ? kZeroBrightness
                                               : minBrightness_);
         }
         state_ = ST_STOPPED;
@@ -430,21 +430,18 @@ class TJLed {
 
         if (t < period) {
             state_ = ST_RUNNING;
-            const auto val = Eval(t);
-            Write(val);
+            Write(Eval(t));
             return true;
         } else {
             if (state_ == ST_RUNNING) {
                 // when in delay after phase, just call Write()
                 // once at the beginning.
                 state_ = ST_IN_DELAY_AFTER_PHASE;
-                const auto val = Eval(period - 1);
-                Write(val);
+                Write(Eval(period - 1));
                 return true;
-            } else {
-                return false;
             }
         }
+        return false;
     }
 
     B& SetBrightnessEval(BrightnessEvaluator* be) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -93,7 +93,7 @@ bin:
 	mkdir -p bin
 
 clean: phony
-	rm -f {*.gcov,*.gcda,*.gcno,*.o} .depend
+	rm -f {./,esp-idf,esp-idf/driver}/{*.gcov,*.gcda,*.gcno,*.o} .depend
 
 clobber: clean
 	rm -f bin/*

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -341,24 +341,24 @@ TEST_CASE("default Stop() sets the brightness to minBrightness", "[jled]") {
     CHECK(50 == jled.Hal().Value());
 }
 
-TEST_CASE("Stop(ABS_ZERO) sets the brightness to 0", "[jled]") {
+TEST_CASE("Stop(FULL_OFF) sets the brightness to 0", "[jled]") {
     auto eval = MockBrightnessEvaluator(ByteVec{100, 0});
     TestJLed jled = TestJLed(10).UserFunc(&eval).MinBrightness(50);
 
     jled.Update();
     REQUIRE(130 == jled.Hal().Value());  // 100 scaled to [50,255]
-    jled.Stop(TestJLed::eStopMode::ABS_ZERO);
+    jled.Stop(TestJLed::eStopMode::FULL_OFF);
 
     CHECK(0 == jled.Hal().Value());
 }
 
-TEST_CASE("Stop(KEEP) keeps the last brightness level", "[jled]") {
+TEST_CASE("Stop(KEEP_CURRENT) keeps the last brightness level", "[jled]") {
     auto eval = MockBrightnessEvaluator(ByteVec{100, 101});
     TestJLed jled = TestJLed(10).UserFunc(&eval).MinBrightness(50);
 
     jled.Update();
     REQUIRE(130 == jled.Hal().Value());  // 100 scaled to [50,255]
-    jled.Stop(TestJLed::eStopMode::KEEP);
+    jled.Stop(TestJLed::eStopMode::KEEP_CURRENT);
 
     CHECK(130 == jled.Hal().Value());
 }


### PR DESCRIPTION
Calling `Stop()`  currently the output level to whatever `min brightness` is set to (default is 0). However, we often to want the LED to be completely off when calling `Stop()` 