### PR TITLE
add JLed version information to generated documentation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,16 +12,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all history for all tags
-      - name: Setup Python 3.13
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-      - name: Install dependencies
-        run: |
-          pip install -r .tools/doc-site/requirements.txt
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
       - name: Generate documentation site
         run: |
-          python .tools/doc-site/generate_site.py --output ./site-build
+          .tools/doc-site/generate_site.py --output ./site-build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/test-build-docs.yml
+++ b/.github/workflows/test-build-docs.yml
@@ -1,0 +1,28 @@
+---
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+name: build doc-site
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build-docs:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all tags
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+      - name: Generate documentation site
+        run: |
+          .tools/doc-site/generate_site.py --output ./site-build
+      - name: Upload doc-site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: doc-site
+          path: ./site-build

--- a/.tools/doc-site/README.md
+++ b/.tools/doc-site/README.md
@@ -39,23 +39,14 @@ The site generator:
 
 ### Prerequisites
 
-Install Python dependencies:
-
-```bash
-pip install -r requirements.txt
-```
-
-Required packages:
-- `markdown>=3.6` - README parsing and HTML rendering
-- `Jinja2>=3.1` - HTML template rendering
-- `packaging>=24.0` - Semantic version parsing and sorting
+[uv](https://docs.astral.sh/uv/) must be installed. The script uses a `uv` shebang and inline dependency metadata, so it self-installs all required packages on first run — no manual `pip install` needed.
 
 ### Running the Generator
 
 From the repository root:
 
 ```bash
-python .tools/doc-site/generate_site.py --output /tmp/jled-docs
+.tools/doc-site/generate_site.py --output /tmp/jled-docs
 ```
 
 Options:
@@ -264,10 +255,9 @@ To modify the generated pages:
 
 ### Updating Dependencies
 
-Update `requirements.txt` and test locally:
+Update the version pins in the `# /// script` inline metadata block at the top of `generate_site.py`, then test locally:
 ```bash
-pip install -r requirements.txt --upgrade
-python generate_site.py --output /tmp/test
+.tools/doc-site/generate_site.py --output /tmp/test
 ```
 
 ### Excluding Versions

--- a/.tools/doc-site/generate_site.py
+++ b/.tools/doc-site/generate_site.py
@@ -55,7 +55,7 @@ EXCLUDE_DIRS = {'CMakeFiles', '.vscode', '.idea', 'build', 'dist', '__pycache__'
 MAX_FILE_SIZE = 500 * 1024  # 500KB
 
 
-def run_git_command(cmd: List[str], cwd: str = None) -> str:
+def run_git_command(cmd: List[str], cwd: str = None, quiet: bool = False) -> str:
     """Run a git command and return the output."""
     try:
         result = subprocess.run(
@@ -67,9 +67,19 @@ def run_git_command(cmd: List[str], cwd: str = None) -> str:
         )
         return result.stdout.strip()
     except subprocess.CalledProcessError as e:
-        print(f"Error running git command: {' '.join(cmd)}", file=sys.stderr)
-        print(f"Error output: {e.stderr}", file=sys.stderr)
+        if not quiet:
+            print(f"Error running git command: {' '.join(cmd)}", file=sys.stderr)
+            print(f"Error output: {e.stderr}", file=sys.stderr)
         raise
+
+
+def resolve_ref(ref: str) -> str:
+    """Return ref if it exists locally, otherwise return origin/ref."""
+    try:
+        run_git_command(['git', 'rev-parse', '--verify', ref], quiet=True)
+        return ref
+    except subprocess.CalledProcessError:
+        return f'origin/{ref}'
 
 
 def get_versions() -> List[str]:
@@ -454,7 +464,7 @@ def generate_example_page(
 
 def checkout_version(version: str, work_dir: str):
     """Checkout a specific version in the given work directory."""
-    run_git_command(['git', 'checkout', '--detach', version], cwd=work_dir)
+    run_git_command(['git', 'checkout', '--detach', resolve_ref(version)], cwd=work_dir)
 
 
 def generate_site(output_dir: str, script_dir: str):
@@ -486,7 +496,7 @@ def generate_site(output_dir: str, script_dir: str):
         # Create worktree using --detach to allow creation even when master is
         # already checked out (e.g. in CI environments).
         print(f"Creating temporary worktree at {work_dir}...")
-        run_git_command(['git', 'worktree', 'add', '--detach', work_dir, 'master'])
+        run_git_command(['git', 'worktree', 'add', '--detach', work_dir, resolve_ref('master')])
 
         try:
             # Process each version

--- a/.tools/doc-site/generate_site.py
+++ b/.tools/doc-site/generate_site.py
@@ -1,4 +1,13 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "markdown>=3.6",
+#     "Jinja2>=3.1",
+#     "packaging>=24.0",
+#     "Pygments>=2.17",
+# ]
+# ///
 """
 JLed Documentation Site Generator
 
@@ -105,7 +114,7 @@ def get_latest_stable(versions: List[str]) -> str:
     return 'master'  # Fallback if no releases exist
 
 
-def extract_readme_structure(readme_path: str) -> tuple[str, List[Dict[str, Any]]]:
+def extract_readme_structure(readme_path: str, version: str = None) -> tuple[str, List[Dict[str, Any]]]:
     """
     Parse README.md and extract HTML content plus navigation structure.
     Returns (html_content, navigation_items).
@@ -127,6 +136,16 @@ def extract_readme_structure(readme_path: str) -> tuple[str, List[Dict[str, Any]
         content,
         flags=re.MULTILINE | re.DOTALL
     )
+
+    # Inject version line after the first top-level heading
+    if version is not None:
+        content = re.sub(
+            r'^(#\s+.+)$',
+            rf'\1\n\nVersion: {version}',
+            content,
+            count=1,
+            flags=re.MULTILINE
+        )
 
     # Configure markdown with TOC extension
     md = markdown.Markdown(
@@ -487,7 +506,7 @@ def generate_site(output_dir: str, script_dir: str):
 
                 # Extract README content and structure
                 if os.path.exists(readme_path):
-                    readme_html, navigation = extract_readme_structure(readme_path)
+                    readme_html, navigation = extract_readme_structure(readme_path, version=ver)
                 else:
                     print(f"Warning: README.md not found for {ver}")
                     readme_html = "<p>Documentation not available for this version.</p>"

--- a/.tools/doc-site/requirements.txt
+++ b/.tools/doc-site/requirements.txt
@@ -1,4 +1,0 @@
-markdown>=3.6
-Jinja2>=3.1
-packaging>=24.0
-Pygments>=2.17


### PR DESCRIPTION
* add Version information to main index page of doc so we see easily, for which version the docs were generated
* test doc-generation in CI
* make generate_site.py self-contained using uv shebang (see https://treyhunner.com/2024/12/lazy-self-installing-python-scripts-with-uv/)