### PR TITLE
Simplify built-in effects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,27 +8,19 @@ JLed is an embedded C++ library for non-blocking, time-driven LED control (blink
 
 ## Repository Structure
 
-| Path | Purpose |
-|------|---------|
-| `src/` | Library source (`.h`/`.cpp`) |
-| `test/` | Host-based unit tests (Catch2, separate Makefile) |
-| `examples/` | MCU `.ino` sketches |
-| `.tools/` | Dev tools (doc site generator) |
-| `platformio.ini` | PlatformIO config |
-| `devbox.json` | Dev environment (Python 3.13, lcov, cpplint, pio) |
+| Path             | Purpose                                           |
+| ---------------- | ------------------------------------------------- |
+| `src/`           | Library source (`.h`/`.cpp`)                      |
+| `test/`          | Host-based unit tests (Catch2, separate Makefile) |
+| `examples/`      | MCU `.ino` sketches                               |
+| `.tools/`        | Dev tools (doc site generator)                    |
+| `platformio.ini` | PlatformIO config                                 |
+| `devbox.json`    | Dev environment (Python 3.13, lcov, cpplint, pio) |
 
 ## Build & Test
 
-```bash
-make lint       # cpplint all C++ files
-make test       # run unit tests + coverage
-make ci         # build all examples for all platforms (~10 min)
-make upload     # flash to MCU
-make monitor    # serial monitor
-make envdump    # dump PlatformIO env info
-```
-
-`test/Makefile` targets: `test`, `clean`, `clobber`, `coverage` (HTML report in `test/report/`)
+- `Makefile` targets: `lint`, `test`, `ci` (build for all platforms examples ~10min), `envdump`
+- `test/Makefile` targets: `test`, `clean`, `clobber`, `coverage` (HTML report in `test/report/`)
 
 ## Code Style
 
@@ -42,21 +34,25 @@ make envdump    # dump PlatformIO env info
 **Strict separation**: state machine logic / effect calculation / hardware access.
 
 **Core files:**
+
 - `src/jled_base.h` — platform-agnostic: `TJLed<Hal, Clock, B>`, `BrightnessEvaluator`, all effects, `TJLedSequence`
 - `src/jled.h` — platform detection (preprocessor macros), exposes `JLed`, `JLedHD`, `JLedSequence`
 - `src/*_hal.h` — HAL per platform (Arduino, ESP32, ESP8266, mbed, Pico)
 
 **HAL**: each platform has two abstractions in `src/*_hal.h`:
+
 - **PWM HAL** (e.g. `ArduinoHal`) — `analogWrite(Brightness val)`
 - **Clock** (e.g. `ArduinoClock`) — `static uint32_t millis()`
 
-**Effects**: implement `BrightnessEvaluator` with `Period()` and `Eval(t)`. Must be stateless and copyable.
+**Effects**: simple structs with `Period()` and `Eval(t)`. Must be stateless and copyable (see
+ConstantBrightnessEvaluator)
 
 **Resolution**: `JLed`/`JLedHD` etc. are template instances; higher resolution = smoother PWM.
 
-**Memory**: placement new into fixed per-instance buffer `brightness_eval_buf_[MAX_SIZE]` (no heap). `MAX_SIZE` = compile-time max of all evaluator sizes.
+**Memory**: no dynamic memory allocation, use fixed buffers or placement new.
 
 **Fluent API** via CRTP — methods return `B&`:
+
 ```cpp
 JLed led = JLed(21).DelayBefore(1500).Breathe(500).Repeat(5).MaxBrightness(150);
 ```
@@ -75,10 +71,9 @@ JLed led = JLed(21).DelayBefore(1500).Breathe(500).Repeat(5).MaxBrightness(150);
 ## Common Tasks
 
 **New effect** (`src/jled_base.h`):
-1. Create evaluator class (see `BlinkBrightnessEvaluator`)
-2. Update `MAX_SIZE` in `TJLed`
-3. Add fluent method: `return SetBrightnessEval(new (brightness_eval_buf_) MyEval(...))`
-4. Add tests in `test/test_jled.cpp`, example in `examples/`, update `README.md`
+
+1. use `BlinkBrightnessEvaluator` and `TJLed::Blink` etc. as reference
+2. Add tests in `test/test_jled.cpp`, example in `examples/`, update `README.md`
 
 **New HAL**: use `src/arduino_hal.h` as reference → create `src/[platform]_hal.h` → add detection in `src/jled.h` → add tests in `test/test_[platform]_hal.cpp`
 
@@ -89,12 +84,12 @@ JLed led = JLed(21).DelayBefore(1500).Breathe(500).Repeat(5).MaxBrightness(150);
 **DO**: preserve API backwards compatibility · add tests for all changes · `make lint && make test` before commit
 
 **DON'T**:
+
 - Add platform-specific code to `jled_base.h`
 - Use float in core logic
 - Use dynamic allocation, exceptions, or RTTI
 - Use `delay()` or blocking operations
 - Break public API without a major version bump
-- Add external dependencies
 - **Change a test to make it pass** — fix the code instead
 
 ## CI/CD

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -92,11 +92,6 @@ Brightness lerp(Brightness val, Brightness a, Brightness b);
 inline uint8_t scale8(uint8_t val, uint8_t f) { return scale<uint8_t>(val, f); }
 inline uint8_t lerp8by8(uint8_t val, uint8_t a, uint8_t b) { return lerp<uint8_t>(val, a, b); }
 
-template <typename T>
-static constexpr T __max(T a, T b) {
-    return (a > b) ? a : b;
-}
-
 // a function f(t,period,param) that calculates the LEDs brightness for a given
 // point in time and the given period. param is an optionally user provided
 // parameter. t will always be in range [0..period-1].
@@ -110,43 +105,21 @@ class BrightnessEvaluator {
 };
 
 template<typename Brightness>
-class CloneableBrightnessEvaluator : public BrightnessEvaluator<Brightness> {
- public:
-    virtual BrightnessEvaluator<Brightness>* clone(void* ptr) const = 0;
-    static void* operator new(size_t, void* ptr) { return ptr; }
-    static void operator delete(void*) {}
-};
-
-template<typename Brightness>
-class ConstantBrightnessEvaluator : public CloneableBrightnessEvaluator<Brightness> {
+struct ConstantBrightnessEvaluator {
     Brightness val_;
     uint16_t duration_;
 
- public:
-    ConstantBrightnessEvaluator() = delete;
-    explicit ConstantBrightnessEvaluator(Brightness val, uint16_t duration = 1)
-        : val_(val), duration_(duration) {}
-    BrightnessEvaluator<Brightness>* clone(void* ptr) const override {
-        return new (ptr) ConstantBrightnessEvaluator(*this);
-    }
-    uint16_t Period() const override { return duration_; }
-    Brightness Eval(uint32_t) const override { return val_; }
+    uint16_t Period() const { return duration_; }
+    Brightness Eval(uint32_t) const { return val_; }
 };
 
 // BlinkBrightnessEvaluator does one on-off cycle in the specified period
 template<typename Brightness>
-class BlinkBrightnessEvaluator : public CloneableBrightnessEvaluator<Brightness> {
+struct BlinkBrightnessEvaluator {
     uint16_t duration_on_, duration_off_;
 
- public:
-    BlinkBrightnessEvaluator() = delete;
-    BlinkBrightnessEvaluator(uint16_t duration_on, uint16_t duration_off)
-        : duration_on_(duration_on), duration_off_(duration_off) {}
-    BrightnessEvaluator<Brightness>* clone(void* ptr) const override {
-        return new (ptr) BlinkBrightnessEvaluator(*this);
-    }
-    uint16_t Period() const override { return duration_on_ + duration_off_; }
-    Brightness Eval(uint32_t t) const override {
+    uint16_t Period() const { return duration_on_ + duration_off_; }
+    Brightness Eval(uint32_t t) const {
         return (t < duration_on_) ? BrightnessTraits<Brightness>::kFullBrightness
                                   : BrightnessTraits<Brightness>::kZeroBrightness;
     }
@@ -159,35 +132,16 @@ class BlinkBrightnessEvaluator : public CloneableBrightnessEvaluator<Brightness>
 //   http://sean.voisen.org/blog/2011/10/breathing-led-with-arduino/
 // But we do it with integers only.
 template<typename Brightness>
-class BreatheBrightnessEvaluator : public CloneableBrightnessEvaluator<Brightness> {
+struct BreatheBrightnessEvaluator {
     uint16_t duration_fade_on_;
     uint16_t duration_on_;
     uint16_t duration_fade_off_;
     Brightness from_;
     Brightness to_;
-
- public:
-    BreatheBrightnessEvaluator() = delete;
-    explicit BreatheBrightnessEvaluator(
-        uint16_t duration_fade_on,
-        uint16_t duration_on,
-        uint16_t duration_fade_off,
-        Brightness from =
-            BrightnessTraits<Brightness>::kZeroBrightness,
-        Brightness to =
-            BrightnessTraits<Brightness>::kFullBrightness)
-        : duration_fade_on_(duration_fade_on),
-          duration_on_(duration_on),
-          duration_fade_off_(duration_fade_off),
-          from_(from),
-          to_(to) {}
-    BrightnessEvaluator<Brightness>* clone(void* ptr) const override {
-        return new (ptr) BreatheBrightnessEvaluator(*this);
-    }
-    uint16_t Period() const override {
+    uint16_t Period() const {
         return duration_fade_on_ + duration_on_ + duration_fade_off_;
     }
-    Brightness Eval(uint32_t t) const override {
+    Brightness Eval(uint32_t t) const {
         Brightness val = BrightnessTraits<Brightness>::kZeroBrightness;
         if (t < duration_fade_on_)
             val = fadeon_func<Brightness>(t, duration_fade_on_);
@@ -206,14 +160,13 @@ class BreatheBrightnessEvaluator : public CloneableBrightnessEvaluator<Brightnes
 };
 
 template<typename Brightness>
-class CandleBrightnessEvaluator : public CloneableBrightnessEvaluator<Brightness> {
+struct CandleBrightnessEvaluator {
     uint8_t speed_;
     uint8_t jitter_;
     uint16_t period_;
     mutable Brightness last_;
     mutable uint32_t last_t_ = 0;
 
- public:
     CandleBrightnessEvaluator() = delete;
 
     // speed - speed of effect (0..15). 0 fastest. Each increment by 1
@@ -225,12 +178,8 @@ class CandleBrightnessEvaluator : public CloneableBrightnessEvaluator<Brightness
           last_(scale<Brightness>(BrightnessTraits<Brightness>::kFullBrightness,
                                       static_cast<Brightness>(5))) {}
 
-    BrightnessEvaluator<Brightness>* clone(void* ptr) const override {
-        return new (ptr) CandleBrightnessEvaluator(*this);
-    }
-
-    uint16_t Period() const override { return period_; }
-    Brightness Eval(uint32_t t) const override {
+    uint16_t Period() const { return period_; }
+    Brightness Eval(uint32_t t) const {
         // idea from
         // https://cpldcpu.wordpress.com/2013/12/08/hacking-a-candleflicker-led/
         // TODO(jd) finetune values
@@ -262,17 +211,61 @@ class CandleBrightnessEvaluator : public CloneableBrightnessEvaluator<Brightness
     }
 };
 
+// Identifies which brightness evaluator is active in EvalStorage.
+enum class EvalType : uint8_t { NONE = 0, CONSTANT, BLINK, BREATHE, CANDLE, USER };
+
+// Type-safe discriminated union holding the active brightness evaluator.
+// Dispatches Period() and Eval() via switch — no virtual functions for
+// built-in effects. The USER arm calls through the user's virtual pointer.
+template<typename Brightness>
+struct EvalStorage {
+    EvalType type = EvalType::NONE;
+
+    union Data {
+        ConstantBrightnessEvaluator<Brightness> constant;
+        BlinkBrightnessEvaluator<Brightness>    blink;
+        BreatheBrightnessEvaluator<Brightness>  breathe;
+        CandleBrightnessEvaluator<Brightness>   candle;
+        BrightnessEvaluator<Brightness>*        user;
+        Data() {}
+        ~Data() {}
+    } data;
+
+    bool IsSet() const { return type != EvalType::NONE; }
+
+    uint16_t Period() const {
+        switch (type) {
+            case EvalType::CONSTANT: return data.constant.Period();
+            case EvalType::BLINK:    return data.blink.Period();
+            case EvalType::BREATHE:  return data.breathe.Period();
+            case EvalType::CANDLE:   return data.candle.Period();
+            case EvalType::USER:     return data.user->Period();
+            default:                 return 0;
+        }
+    }
+
+    Brightness Eval(uint32_t t) const {
+        switch (type) {
+            case EvalType::CONSTANT: return data.constant.Eval(t);
+            case EvalType::BLINK:    return data.blink.Eval(t);
+            case EvalType::BREATHE:  return data.breathe.Eval(t);
+            case EvalType::CANDLE:   return data.candle.Eval(t);
+            case EvalType::USER:     return data.user->Eval(t);
+            default:                 return BrightnessTraits<Brightness>::kZeroBrightness;
+        }
+    }
+};
+
 template <typename Hal, typename Clock, typename Brightness, typename Derived>
 class TJLed {
  protected:
-    // pointer to a (user defined) brightness evaluator.
-    BrightnessEvaluator<Brightness>* brightness_eval_ = nullptr;
+    // Active brightness evaluator (discriminated union).
+    EvalStorage<Brightness> eval_storage_;
     // Hardware abstraction giving access to the MCU
     Hal hal_;
 
-    // Evaluate effect(t) and scale to be within [minBrightness, maxBrightness]
-    // assumes brigthness_eval_ is set as it is not checked here.
-    Brightness Eval(uint32_t t) const { return brightness_eval_->Eval(t); }
+    // Evaluate effect(t) — assumes eval_storage_.IsSet().
+    Brightness Eval(uint32_t t) const { return eval_storage_.Eval(t); }
 
     // Write val out to the "hardware", inverting signal when active-low is set.
     void Write(Brightness val) {
@@ -309,18 +302,7 @@ class TJLed {
         delay_after_ = rLed.delay_after_;
         time_start_ = rLed.time_start_;
         hal_ = rLed.hal_;
-
-        if (rLed.brightness_eval_ !=
-            reinterpret_cast<const BrightnessEvaluator<Brightness>*>(
-                rLed.brightness_eval_buf_)) {
-            // nullptr or points to (external) user provided evaluator
-            brightness_eval_ = rLed.brightness_eval_;
-        } else {
-            brightness_eval_ =
-                (reinterpret_cast<const CloneableBrightnessEvaluator<Brightness>*>(
-                     rLed.brightness_eval_))
-                    ->clone(brightness_eval_buf_);
-        }
+        eval_storage_ = rLed.eval_storage_;
         return static_cast<Derived&>(*this);
     }
 
@@ -348,29 +330,27 @@ class TJLed {
     // Sets LED to given brightness. As for every effect, a duration can be
     // specified. Update() will return false after the duration elapsed.
     Derived& Set(Brightness brightness, uint16_t duration = 1) {
-        // note: we use placement new and therefore not need to keep track of
-        // mem allocated
-        return SetBrightnessEval(
-            new (brightness_eval_buf_)
-                ConstantBrightnessEvaluator<Brightness>(brightness, duration));
+        eval_storage_.type = EvalType::CONSTANT;
+        eval_storage_.data.constant = {brightness, duration};
+        return Reset();
     }
 
     // Fade LED on
     Derived& FadeOn(uint16_t duration,
                     Brightness from = BrightnessTraits<Brightness>::kZeroBrightness,
                     Brightness to = BrightnessTraits<Brightness>::kFullBrightness) {
-        return SetBrightnessEval(
-            new (brightness_eval_buf_)
-                BreatheBrightnessEvaluator<Brightness>(duration, 0, 0, from, to));
+        eval_storage_.type = EvalType::BREATHE;
+        eval_storage_.data.breathe = {duration, 0, 0, from, to};
+        return Reset();
     }
 
-    // Fade LED off - acutally is just inverted version of FadeOn()
+    // Fade LED off - actually is just inverted version of FadeOn()
     Derived& FadeOff(uint16_t duration,
                      Brightness from = BrightnessTraits<Brightness>::kFullBrightness,
                      Brightness to = BrightnessTraits<Brightness>::kZeroBrightness) {
-        return SetBrightnessEval(
-            new (brightness_eval_buf_)
-                BreatheBrightnessEvaluator<Brightness>(0, 0, duration, to, from));
+        eval_storage_.type = EvalType::BREATHE;
+        eval_storage_.data.breathe = {0, 0, duration, to, from};
+        return Reset();
     }
 
     // Fade from "from" to "to" with period "duration". Sets up the breathe
@@ -391,29 +371,33 @@ class TJLed {
     // duration values.
     Derived& Breathe(uint16_t duration_fade_on, uint16_t duration_on,
                      uint16_t duration_fade_off) {
-        return SetBrightnessEval(
-            new (brightness_eval_buf_) BreatheBrightnessEvaluator<Brightness>(
-                duration_fade_on, duration_on, duration_fade_off));
+        eval_storage_.type = EvalType::BREATHE;
+        eval_storage_.data.breathe = {duration_fade_on, duration_on, duration_fade_off,
+            BrightnessTraits<Brightness>::kZeroBrightness,
+            BrightnessTraits<Brightness>::kFullBrightness};
+        return Reset();
     }
 
     // Set effect to Blink, with the given on- and off- duration values.
     Derived& Blink(uint16_t duration_on, uint16_t duration_off) {
-        return SetBrightnessEval(
-            new (brightness_eval_buf_)
-                BlinkBrightnessEvaluator<Brightness>(duration_on, duration_off));
+        eval_storage_.type = EvalType::BLINK;
+        eval_storage_.data.blink = {duration_on, duration_off};
+        return Reset();
     }
 
     // Set effect to Candle light simulation
     Derived& Candle(uint8_t speed = 6, uint8_t jitter = 15,
                     uint16_t period = 0xffff) {
-        return SetBrightnessEval(
-            new (brightness_eval_buf_)
-                CandleBrightnessEvaluator<Brightness>(speed, jitter, period));
+        eval_storage_.type = EvalType::CANDLE;
+        eval_storage_.data.candle = CandleBrightnessEvaluator<Brightness>(speed, jitter, period);
+        return Reset();
     }
 
     // Use a user provided brightness evaluator.
     Derived& UserFunc(BrightnessEvaluator<Brightness>* user_eval) {
-        return SetBrightnessEval(user_eval);
+        eval_storage_.type = EvalType::USER;
+        eval_storage_.data.user = user_eval;
+        return Reset();
     }
 
     // set number of repetitions for effect.
@@ -500,7 +484,7 @@ class TJLed {
     }
 
     bool Update(uint32_t t, int16_t* pLast = nullptr) {
-        if (state_ == ST_STOPPED || !brightness_eval_) return false;
+        if (state_ == ST_STOPPED || !eval_storage_.IsSet()) return false;
 
         if (state_ == ST_INIT) {
             time_start_ = t + delay_before_;
@@ -522,7 +506,7 @@ class TJLed {
             Write(val);
         };
 
-        const auto period = brightness_eval_->Period();
+        const auto period = eval_storage_.Period();
         const auto cycle_period = period + delay_after_;
 
         if (!IsForever()) {
@@ -562,12 +546,6 @@ class TJLed {
 
     void trackLastUpdateTime(uint32_t t) { last_update_time_ = (t & 255); }
 
-    Derived& SetBrightnessEval(BrightnessEvaluator<Brightness>* be) {
-        brightness_eval_ = be;
-        // start over after the brightness evaluator changed
-        return Reset();
-    }
-
  public:
     // Number of bits used to control brightness with Min/MaxBrightness().
     static constexpr uint8_t kBitsBrightness = BrightnessTraits<Brightness>::kBits;
@@ -583,16 +561,6 @@ class TJLed {
     uint8_t bLowActive_ : 1;
     Brightness minBrightness_;
     Brightness maxBrightness_;
-
-    // this is where the BrightnessEvaluator object will be stored using
-    // placment new.  Set MAX_SIZE to class occupying most memory
-    static constexpr auto MAX_SIZE =
-        __max(sizeof(CandleBrightnessEvaluator<Brightness>),
-              __max(sizeof(BreatheBrightnessEvaluator<Brightness>),
-                    __max(sizeof(ConstantBrightnessEvaluator<Brightness>),  // NOLINT
-                          sizeof(BlinkBrightnessEvaluator<Brightness>))));
-    alignas(alignof(
-        CloneableBrightnessEvaluator<Brightness>)) char brightness_eval_buf_[MAX_SIZE];
 
     static constexpr uint16_t kRepeatForever = 65535;
     uint16_t num_repetitions_ = 1;

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -67,9 +67,8 @@ TEST_CASE("On/Off function configuration", "[jled]") {
                 "on") {
                 TestableJLed jled(1);
                 jled.On();
-                REQUIRE(dynamic_cast<ConstantBrightnessEvaluator *>(
-                            jled.brightness_eval_) != nullptr);
-                CHECK(jled.brightness_eval_->Eval(0) == 255);
+                REQUIRE(jled.eval_storage_.type == jled::EvalType::CONSTANT);
+                CHECK(jled.eval_storage_.Eval(0) == 255);
             }
 
             SECTION(
@@ -77,25 +76,22 @@ TEST_CASE("On/Off function configuration", "[jled]") {
                 "off") {
                 TestableJLed jled(1);
                 jled.Off();
-                REQUIRE(dynamic_cast<ConstantBrightnessEvaluator *>(
-                            jled.brightness_eval_) != nullptr);
-                CHECK(jled.brightness_eval_->Eval(0) == 0);
+                REQUIRE(jled.eval_storage_.type == jled::EvalType::CONSTANT);
+                CHECK(jled.eval_storage_.Eval(0) == 0);
             }
 
             SECTION("using Set() allows to set custom brightness level") {
                 TestableJLed jled(1);
                 jled.Set(123);
-                REQUIRE(dynamic_cast<ConstantBrightnessEvaluator *>(
-                            jled.brightness_eval_) != nullptr);
-                CHECK(jled.brightness_eval_->Eval(0) == 123);
+                REQUIRE(jled.eval_storage_.type == jled::EvalType::CONSTANT);
+                CHECK(jled.eval_storage_.Eval(0) == 123);
             }
 
             SECTION("using Set(0) allows to set custom turn LED off") {
                 TestableJLed jled(1);
                 jled.Set(0);
-                REQUIRE(dynamic_cast<ConstantBrightnessEvaluator *>(
-                            jled.brightness_eval_) != nullptr);
-                CHECK(jled.brightness_eval_->Eval(0) == 0);
+                REQUIRE(jled.eval_storage_.type == jled::EvalType::CONSTANT);
+                CHECK(jled.eval_storage_.Eval(0) == 0);
             }
         }
     };
@@ -109,13 +105,11 @@ TEST_CASE("using Breathe() configures BreatheBrightnessEvaluator", "[jled]") {
         static void test() {
             TestableJLed jled(1);
             jled.Breathe(100, 200, 300);
-            REQUIRE(dynamic_cast<BreatheBrightnessEvaluator *>(
-                        jled.brightness_eval_) != nullptr);
-            auto eval = dynamic_cast<BreatheBrightnessEvaluator *>(
-                jled.brightness_eval_);
-            CHECK(100 == eval->DurationFadeOn());
-            CHECK(200 == eval->DurationOn());
-            CHECK(300 == eval->DurationFadeOff());
+            REQUIRE(jled.eval_storage_.type == jled::EvalType::BREATHE);
+            auto& eval = jled.eval_storage_.data.breathe;
+            CHECK(100 == eval.DurationFadeOn());
+            CHECK(200 == eval.DurationOn());
+            CHECK(300 == eval.DurationFadeOff());
         }
     };
     TestableJLed::test();
@@ -129,13 +123,11 @@ TEST_CASE("Breathe(period) splits period evenly into fade-on and fade-off",
         static void test() {
             TestableJLed jled(1);
             jled.Breathe(1000);
-            REQUIRE(dynamic_cast<BreatheBrightnessEvaluator *>(
-                        jled.brightness_eval_) != nullptr);
-            auto eval = dynamic_cast<BreatheBrightnessEvaluator *>(
-                jled.brightness_eval_);
-            CHECK(500 == eval->DurationFadeOn());
-            CHECK(0 == eval->DurationOn());
-            CHECK(500 == eval->DurationFadeOff());
+            REQUIRE(jled.eval_storage_.type == jled::EvalType::BREATHE);
+            auto& eval = jled.eval_storage_.data.breathe;
+            CHECK(500 == eval.DurationFadeOn());
+            CHECK(0 == eval.DurationOn());
+            CHECK(500 == eval.DurationFadeOff());
         }
     };
     TestableJLed::test();
@@ -148,8 +140,7 @@ TEST_CASE("using Candle() configures CandleBrightnessEvaluator", "[jled]") {
         static void test() {
             TestableJLed jled(1);
             jled.Candle(1, 2, 3);
-            REQUIRE(dynamic_cast<CandleBrightnessEvaluator *>(
-                        jled.brightness_eval_) != nullptr);
+            REQUIRE(jled.eval_storage_.type == jled::EvalType::CANDLE);
         }
     };
     TestableJLed::test();
@@ -164,24 +155,20 @@ TEST_CASE("using Fadeon(), FadeOff() configures Fade-BrightnessEvaluators",
             SECTION("FadeOff() initializes with BreatheBrightnessEvaluator") {
                 TestableJLed jled(1);
                 jled.FadeOff(100);
-                REQUIRE(dynamic_cast<BreatheBrightnessEvaluator *>(
-                            jled.brightness_eval_) != nullptr);
-                auto eval = dynamic_cast<BreatheBrightnessEvaluator *>(
-                    jled.brightness_eval_);
-                CHECK(0 == eval->DurationFadeOn());
-                CHECK(0 == eval->DurationOn());
-                CHECK(100 == eval->DurationFadeOff());
+                REQUIRE(jled.eval_storage_.type == jled::EvalType::BREATHE);
+                auto& eval = jled.eval_storage_.data.breathe;
+                CHECK(0 == eval.DurationFadeOn());
+                CHECK(0 == eval.DurationOn());
+                CHECK(100 == eval.DurationFadeOff());
             }
             SECTION("FadeOn() initializes with BreatheBrightnessEvaluator") {
                 TestableJLed jled(1);
                 jled.FadeOn(100);
-                REQUIRE(dynamic_cast<BreatheBrightnessEvaluator *>(
-                            jled.brightness_eval_) != nullptr);
-                auto eval = dynamic_cast<BreatheBrightnessEvaluator *>(
-                    jled.brightness_eval_);
-                CHECK(100 == eval->DurationFadeOn());
-                CHECK(0 == eval->DurationOn());
-                CHECK(0 == eval->DurationFadeOff());
+                REQUIRE(jled.eval_storage_.type == jled::EvalType::BREATHE);
+                auto& eval = jled.eval_storage_.data.breathe;
+                CHECK(100 == eval.DurationFadeOn());
+                CHECK(0 == eval.DurationOn());
+                CHECK(0 == eval.DurationFadeOff());
             }
         }
     };
@@ -196,28 +183,24 @@ TEST_CASE("using Fade() configures BreatheBrightnessEvaluator", "[jled]") {
             SECTION("fade with from < to") {
                 TestableJLed jled(1);
                 jled.Fade(100, 200, 300);  // from, to, duration
-                REQUIRE(dynamic_cast<BreatheBrightnessEvaluator *>(
-                            jled.brightness_eval_) != nullptr);
-                auto eval = dynamic_cast<BreatheBrightnessEvaluator *>(
-                    jled.brightness_eval_);
-                CHECK(300 == eval->DurationFadeOn());
-                CHECK(0 == eval->DurationOn());
-                CHECK(0 == eval->DurationFadeOff());
-                CHECK(100 == static_cast<int>(eval->From()));
-                CHECK(200 == static_cast<int>(eval->To()));
+                REQUIRE(jled.eval_storage_.type == jled::EvalType::BREATHE);
+                auto& eval = jled.eval_storage_.data.breathe;
+                CHECK(300 == eval.DurationFadeOn());
+                CHECK(0 == eval.DurationOn());
+                CHECK(0 == eval.DurationFadeOff());
+                CHECK(100 == static_cast<int>(eval.From()));
+                CHECK(200 == static_cast<int>(eval.To()));
             }
             SECTION("fade with from >= to") {
                 TestableJLed jled(1);
                 jled.Fade(200, 100, 300);
-                REQUIRE(dynamic_cast<BreatheBrightnessEvaluator *>(
-                            jled.brightness_eval_) != nullptr);
-                auto eval = dynamic_cast<BreatheBrightnessEvaluator *>(
-                    jled.brightness_eval_);
-                CHECK(0 == eval->DurationFadeOn());
-                CHECK(0 == eval->DurationOn());
-                CHECK(300 == eval->DurationFadeOff());
-                CHECK(100 == static_cast<int>(eval->From()));
-                CHECK(200 == static_cast<int>(eval->To()));
+                REQUIRE(jled.eval_storage_.type == jled::EvalType::BREATHE);
+                auto& eval = jled.eval_storage_.data.breathe;
+                CHECK(0 == eval.DurationFadeOn());
+                CHECK(0 == eval.DurationOn());
+                CHECK(300 == eval.DurationFadeOff());
+                CHECK(100 == static_cast<int>(eval.From()));
+                CHECK(200 == static_cast<int>(eval.To()));
             }
         }
     };
@@ -231,8 +214,7 @@ TEST_CASE("UserFunc() allows to use a custom brightness evaluator", "[jled]") {
             TestableJLed jled(1);
             auto cust = MockBrightnessEvaluator(ByteVec{});
             jled.UserFunc(&cust);
-            REQUIRE(dynamic_cast<MockBrightnessEvaluator *>(
-                        jled.brightness_eval_) != nullptr);
+            REQUIRE(jled.eval_storage_.type == jled::EvalType::USER);
         }
     };
     TestableJLed::test();
@@ -240,12 +222,12 @@ TEST_CASE("UserFunc() allows to use a custom brightness evaluator", "[jled]") {
 
 TEST_CASE("ConstantBrightnessEvaluator returns constant provided value",
           "[jled]") {
-    auto cbZero = ConstantBrightnessEvaluator(0);
+    auto cbZero = ConstantBrightnessEvaluator{0, 1};
     CHECK(1 == cbZero.Period());
     CHECK(0 == cbZero.Eval(0));
     CHECK(0 == cbZero.Eval(1000));
 
-    auto cbFull = ConstantBrightnessEvaluator(255);
+    auto cbFull = ConstantBrightnessEvaluator{255, 1};
     CHECK(1 == cbFull.Period());
     CHECK(255 == cbFull.Eval(0));
     CHECK(255 == cbFull.Eval(1000));
@@ -255,7 +237,7 @@ TEST_CASE(
     "BlinkBrightnessEvaluator calculates switches between on and off in given "
     "time frames",
     "[jled]") {
-    auto eval = BlinkBrightnessEvaluator(10, 5);
+    auto eval = BlinkBrightnessEvaluator{10, 5};
     CHECK(10 + 5 == eval.Period());
     CHECK(255 == eval.Eval(0));
     CHECK(255 == eval.Eval(9));
@@ -273,7 +255,7 @@ TEST_CASE("CandleBrightnessEvaluator simulated candle flickering", "[jled]") {
 TEST_CASE(
     "BreatheEvaluator evaluates to bell curve distributed brightness curve",
     "[jled]") {
-    auto eval = BreatheBrightnessEvaluator(100, 200, 300);
+    auto eval = BreatheBrightnessEvaluator{100, 200, 300, 0, 255};
     CHECK(100 + 200 + 300 == eval.Period());
 
     const std::map<uint32_t, uint8_t> test_values = {


### PR DESCRIPTION
Effects (except for user defined effects) no longer use virtual methods. This improves performance, reduces memory consumption (no vtable pointer needed) and simplifies the code.