### PR TITLE
Fix Pico HAL not being fully off when LED is LowActive()

### DIFF
--- a/src/pico_hal.h
+++ b/src/pico_hal.h
@@ -83,7 +83,11 @@ class PicoHal {
     template<typename Brightness>
     void analogWrite(Brightness val) const {
         const uint16_t duty = jled::scaleToNative<kResBits_>(val);
-        pwm_set_chan_level(slice_num_, channel_, duty);
+        // Level kWrap+1 means fully on; adding the bool is branchless on ARM.
+        // Guard prevents uint16_t overflow at kResBits_=16 and folds away at compile time.
+        const uint16_t full_duty =
+            duty + static_cast<uint16_t>(kResBits_ < 16 && duty == kWrap);
+        pwm_set_chan_level(slice_num_, channel_, full_duty);
     }
 
  private:

--- a/test/hal_mock.h
+++ b/test/hal_mock.h
@@ -15,21 +15,30 @@ class HalMock {
 
     template<typename Brightness>
     void analogWrite(Brightness val) {
-        // For testing, always store as uint8_t (downscale if needed)
-        // Use sizeof for compile-time optimization (optimizes same as if constexpr)
-        if (sizeof(Brightness) == 1) {
-            val_ = val;
-        } else {
-            val_ = static_cast<uint8_t>(val >> 8);
-        }
+        val_ = static_cast<uint16_t>(val);
+        pin_values()[pin_] = val_;
     }
 
-    uint8_t Pin() const { return pin_; }
-    uint8_t Value() const { return val_; }
+    uint8_t  Pin()   const { return pin_; }
+    uint16_t Value() const { return val_; }
+
+    // Global pin-state table: allows reading back brightness from LEDs stored
+    // inside type-erased containers (where GetHal() is not accessible).
+    static uint16_t PinValue(uint8_t pin) { return pin_values()[pin]; }
+
+    static void Init() {
+        uint16_t* p = pin_values();
+        for (int i = 0; i < 256; i++) p[i] = 0;
+    }
 
  private:
-    uint8_t val_ = 0;
-    PinType pin_ = 0;
+    uint16_t val_ = 0;
+    PinType  pin_ = 0;
+
+    static uint16_t* pin_values() {
+        static uint16_t values[256] = {};
+        return values;
+    }
 };
 
 class TimeMock {

--- a/test/test_mbed_hal.cpp
+++ b/test/test_mbed_hal.cpp
@@ -79,5 +79,5 @@ TEST_CASE("mbed_hal copy assignment writes to correct pin", "[mbed_hal]") {
 
 TEST_CASE("mbed_hal destructs without crash when uninitialised", "[mbed_hal]") {
     mbedMockInit();
-    { MbedHal<> hal(5); }  // pwmout_ is null — must not crash
+    { MbedHal<> hal(5); }  // pwmout_ is null, must not crash
 }

--- a/test/test_pico_hal.cpp
+++ b/test/test_pico_hal.cpp
@@ -43,7 +43,7 @@ TEST_CASE("constructor enables PWM slice", "[pico_hal]") {
     REQUIRE(picoMockGetPwmEnabled(kSlice) == true);
 }
 
-TEST_CASE("analogWrite() 8-bit: duty passes through directly", "[pico_hal]") {
+TEST_CASE("analogWrite() 8-bit: zero and mid-range pass through unchanged", "[pico_hal]") {
     picoMockInit();
     PicoHal<> hal(kPin);
 
@@ -52,9 +52,21 @@ TEST_CASE("analogWrite() 8-bit: duty passes through directly", "[pico_hal]") {
 
     hal.analogWrite<uint8_t>(128);
     REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 128);
+}
 
+TEST_CASE("analogWrite() 8-bit: max brightness gets full-on fix (255->256)", "[pico_hal]") {
+    picoMockInit();
+    PicoHal<> hal(kPin);
     hal.analogWrite<uint8_t>(255);
-    REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 255);
+    REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 256);
+}
+
+TEST_CASE("analogWrite() 16-bit input at max brightness gets full-on fix", "[pico_hal]") {
+    picoMockInit();
+    PicoHal<> hal(kPin);
+    // scaleToNative<8>(65535) = 65535>>8 = 255 = kWrap; fix applies: 255+1 = 256
+    hal.analogWrite<uint16_t>(65535);
+    REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 256);
 }
 
 TEST_CASE("PicoHal<10>: 8-bit input upscaled to 10-bit", "[pico_hal]") {
@@ -65,8 +77,8 @@ TEST_CASE("PicoHal<10>: 8-bit input upscaled to 10-bit", "[pico_hal]") {
     REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 0);
 
     hal.analogWrite<uint8_t>(255);
-    // scaleToNative<10>(255u8) = (255<<2)|(255>>6) = 1020|3 = 1023
-    REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 1023);
+    // scaleToNative<10>(255u8) = (255<<2)|(255>>6) = 1020|3 = 1023 = kWrap; fix: 1023+1=1024
+    REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 1024);
 }
 
 TEST_CASE("PicoHal<10>: 16-bit input downscaled to 10-bit", "[pico_hal]") {
@@ -77,8 +89,24 @@ TEST_CASE("PicoHal<10>: 16-bit input downscaled to 10-bit", "[pico_hal]") {
     REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 0);
 
     hal.analogWrite<uint16_t>(65535);
-    // scaleToNative<10>(65535u16) = 65535 >> 6 = 1023
-    REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 1023);
+    // scaleToNative<10>(65535u16) = 65535>>6 = 1023 = kWrap; fix: 1023+1=1024
+    REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 1024);
+}
+
+TEST_CASE("PicoHal<10>: max 8-bit input gets full-on fix (1023->1024)", "[pico_hal]") {
+    picoMockInit();
+    PicoHal<10> hal(kPin);
+    // scaleToNative<10>(255) = (255<<2)|(255>>6) = 1020|3 = 1023 = kWrap; fix: 1023+1 = 1024
+    hal.analogWrite<uint8_t>(255);
+    REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 1024);
+}
+
+TEST_CASE("PicoHal<16>: max brightness does not apply full-on fix", "[pico_hal]") {
+    picoMockInit();
+    PicoHal<16> hal(kPin);
+    // kWrap+1 = 65536 overflows uint16_t; fix is intentionally skipped
+    hal.analogWrite<uint16_t>(65535);
+    REQUIRE(picoMockGetPwmChanLevel(kSlice, kChan) == 65535);
 }
 
 TEST_CASE("PicoClock::millis() returns 0 at boot", "[pico_hal]") {


### PR DESCRIPTION
when LED is inverted (LowActive()) the PWM value must be set to 2^res since otherwise there will be a light remaining glim when the LED  is supposed to be off.