### PR TITLE
Use `act` to run testmatrix locally

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,1 @@
+-P ubuntu-24.04=catthehacker/ubuntu:act-24.04

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: '[gh-actions] '
+    groups:
+      all-dependencies:
+        patterns: ['*']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.13'
+      - name: install cpplint
+        run: pip install cpplint==2.0.0
       - name: linter
-        run: |
-          pip install cpplint==2.0.0
-          make lint
+        run: make lint
   test:
     runs-on: ubuntu-24.04
     steps:
@@ -60,40 +60,10 @@ jobs:
         with:
           name: coverage-report
           path: test/report/
-  setup-examples:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v6
-      - name: install python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-      - name: Cache PlatformIO
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.platformio
-            ~/.cache/pip
-          key: ${{ runner.os }}-pio-${{ hashFiles('**/platformio.ini', '.github/workflows/test.yml')
-            }}
-          restore-keys: |
-            ${{ runner.os }}-pio-
-      - name: install tools
-        uses: ./.github/actions/setup-platformio
-      - name: install rpipico platform and toolchain
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          pio platform install "https://github.com/maxgerhardt/platform-raspberrypi.git"
-          pio ci --board=rpipico \
-              --lib="src" \
-              --project-option="board_build.core = earlephilhower" \
-              "examples/hello/hello.ino"
   examples:
-    needs: setup-examples
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         board: [uno, esp01, nano33ble, esp32dev, rpipico]
         example:
@@ -123,14 +93,16 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v6
       - name: Cache PlatformIO
+        id: cache-pio
         uses: actions/cache@v4
         with:
           path: |
             ~/.platformio
             ~/.cache/pip
-          key: ${{ runner.os }}-pio-${{ hashFiles('**/platformio.ini', '.github/workflows/test.yml')
-            }}
+          key: ${{ runner.os }}-pio-${{ matrix.board }}-${{ hashFiles('**/platformio.ini',
+            '.github/workflows/test.yml') }}
           restore-keys: |
+            ${{ runner.os }}-pio-${{ matrix.board }}-
             ${{ runner.os }}-pio-
       - name: install python
         uses: actions/setup-python@v6
@@ -138,6 +110,10 @@ jobs:
           python-version: '3.13'
       - name: install tools
         uses: ./.github/actions/setup-platformio
+      - name: install rpipico platform
+        if: matrix.board == 'rpipico' && steps.cache-pio.outputs.cache-hit != 'true'
+        run: |
+          pio platform install "https://github.com/maxgerhardt/platform-raspberrypi.git"
       - name: build examples
         run: |-
           # the mbed examples explicitely sets the extension to cpp, default is ino

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ test/report.info
 userstories/
 .doc-site/
 .tools/fade-func/
+.act-run.*/
+.pio-cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,9 @@ JLed led = JLed(21).DelayBefore(1500).Breathe(500).Repeat(5).MaxBrightness(150);
 
 ## CI/CD
 
-GitHub Actions (`.github/workflows/test.yml`) on push/PR to `master`: lint → unit tests + coverage (Coveralls) → `make ci`. All must pass.
+CI runs unit tests and a test matrix of `examples/` and selected MCUs. Locally `act` is
+used to run the test matrix (`make act-ci-run`).
+GitHub Actions (`.github/workflows/test.yml`) on push/PR to `master`: lint → unit tests + coverage (Coveralls) → `make act-ci-run`. All must pass.
 
 ## Documentation Site
 

--- a/Makefile
+++ b/Makefile
@@ -1,55 +1,70 @@
 # use this makefile to build with platformio
 #
+SHELL := /bin/bash
 .PHONY: phony
-
-# some of the examples use LED_BUILTIN which is not defined for ESP32
-CIOPTS=--board=uno --board=esp01 --board=nano33ble --lib="src"
-CIOPTS_MBED=--board=nucleo_f401re -Oframework=mbed --lib="src"
-CIOPTSALL=--board=esp32dev --board=uno --board=nano33ble --board=esp01 --lib="src"
+RUN := $(if $(shell which devbox 2>/dev/null),devbox run --,)
 
 all: phony
-	pio run
+	$(RUN) pio run
 
 lint: phony
-	cpplint --filter -readability/check,-build/include_subdir \
+	$(RUN) cpplint --filter -readability/check,-build/include_subdir \
 		    --linelength=100\
 		    --exclude test/catch2 \
 		    --extensions=cpp,h,ino $(shell find . -maxdepth 3 \( ! -regex '.*/\..*' \) \
 		       -type f -a \( -name "*\.cpp" -o -name "*\.h" -o -name "*\.ino" \) )
 
-ci: phony
-	pio ci $(CIOPTS) examples/custom_hal/custom_hal.ino
-	pio ci $(CIOPTS_MBED) examples/multiled_mbed/multiled_mbed.cpp
-	pio ci $(CIOPTS) --lib="examples/morse" examples/morse/morse.ino
-	pio ci $(CIOPTS) examples/candle/candle.ino
-	pio ci $(CIOPTS) examples/multiled/multiled.ino
-	pio ci $(CIOPTS) examples/user_func/user_func.ino
-	pio ci $(CIOPTS) examples/hello/hello.ino
-	pio ci $(CIOPTSALL) examples/breathe/breathe.ino
-	pio ci $(CIOPTS) examples/simple_on/simple_on.ino
-	pio ci $(CIOPTSALL) examples/fade_on/fade_on.ino
-	pio ci $(CIOPTSALL) examples/sequence/sequence.ino
+test: phony
+	$(RUN) $(MAKE) -C test coverage
+
+# Seed ~/.cache/act/ before the parallel run. Parallel matrix jobs race on
+# git-cloning the same actions simultaneously, corrupting the download
+# (https://github.com/nektos/act/issues/1943, closed won't-fix).
+# Run one real job first to fully populate the action cache; --action-offline-mode
+# on the main run then prevents any re-cloning during the parallel execution.
+ACT_CONTAINER_OPTS = -v $(CURDIR)/.pio-cache:/home/runner/.platformio
+
+ci-act: phony
+	@set -e; \
+	OUTDIR=$$(mktemp -d "$(CURDIR)/.act-run.XXXXXX"); \
+	echo "Act output dir: $$OUTDIR"; \
+	mkdir -p "$(CURDIR)/.pio-cache"; \
+	# Seed: run one real job so ~/.cache/act/ is populated before the parallel run. \
+	$(RUN) act --job examples \
+	    --matrix board:uno --matrix example:hello --env ACT=true \
+	    --container-options "$(ACT_CONTAINER_OPTS)" \
+	    || true; \
+	ACT_LOG=$$OUTDIR/act.ndjson; \
+	$(RUN) act --job examples --json --action-offline-mode \
+	    --env ACT=true \
+	    --container-options "$(ACT_CONTAINER_OPTS)" \
+	    2>&1 | tee $$ACT_LOG | jq -Rr 'try (fromjson | .msg // empty) catch empty' || true; \
+	jq -Rr 'try (fromjson | select(.matrix.board? and .matrix.example?) | "\(.matrix.board)\t\(.matrix.example)\t\(tojson)") catch empty' $$ACT_LOG \
+	    | while IFS=$$'\t' read -r board example json; do \
+	        printf '%s\n' "$$json" >> $$OUTDIR/$${board}_$${example}.ndjson; \
+	    done; \
+	printf '=== Summary ===\n'; \
+	jq -Rr 'try (fromjson | select(.jobResult != null and .matrix.board != null) | [if .jobResult == "success" then "OK" else "FAIL" end, .matrix.board, .matrix.example] | @tsv) catch empty' $$ACT_LOG \
+	    | sort | grep . | column -t
+
 
 envdump: phony
-	-pio run --target envdump
+	-$(RUN) pio run --target envdump
 
 clean: phony
-	-pio run --target clean
-	cd test && make clean
+	-$(RUN) pio run --target clean
+	make -C test clean
 	rm -f src/{*.o,*.gcno,*.gcda}
 	rm -rf .doc-site/
 
 upload: phony
-	pio run --target upload
+	$(RUN) pio run --target upload
 
 monitor: phony
-	pio device monitor
-
-test: phony
-	$(MAKE) -C test coverage
+	$(RUN) pio device monitor
 
 docs: phony
-	.tools/doc-site/generate_site.py --output .doc-site
+	$(RUN) .tools/doc-site/generate_site.py --output .doc-site
 
 tags: phony
-	ctags -R
+	$(RUN) ctags -R

--- a/devbox.json
+++ b/devbox.json
@@ -2,7 +2,8 @@
   "packages": [
     "python@3.13",
     "python3Packages.pip",
-    "cpplint@2.0.2"
+    "cpplint@2.0.2",
+    "act@latest"
   ],
   "shell": {
     "init_hook": [

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,9 +1,57 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "act@latest": {
+      "last_modified": "2026-05-21T08:15:18Z",
+      "resolved": "github:NixOS/nixpkgs/4a29d733e8a7d5b824c3d8c958a946a9867b3eb2#act",
+      "source": "devbox-search",
+      "version": "0.2.88",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fmhnq6fn426v0crip0mkbqns2lv9251j-act-0.2.88",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fmhnq6fn426v0crip0mkbqns2lv9251j-act-0.2.88"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/pdp7yd81ryadh5whbcmdnq87l732jc7b-act-0.2.88",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/pdp7yd81ryadh5whbcmdnq87l732jc7b-act-0.2.88"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/cxphgb801n8smiqy4a64bnq6fz0dggyc-act-0.2.88",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/cxphgb801n8smiqy4a64bnq6fz0dggyc-act-0.2.88"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1h0krxwvbs1s4vpvdlv9snlpsylzwdka-act-0.2.88",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1h0krxwvbs1s4vpvdlv9snlpsylzwdka-act-0.2.88"
+        }
+      }
+    },
     "cpplint@2.0.2": {
-      "last_modified": "2026-01-23T17:20:52Z",
-      "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#cpplint",
+      "last_modified": "2026-05-21T08:15:18Z",
+      "resolved": "github:NixOS/nixpkgs/4a29d733e8a7d5b824c3d8c958a946a9867b3eb2#cpplint",
       "source": "devbox-search",
       "version": "2.0.2",
       "systems": {
@@ -11,63 +59,63 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/8zcvfkbngakvd90611rgb42d3sxyy67b-cpplint-2.0.2",
+              "path": "/nix/store/lz8hhjga6jq633fi5d9zx5igp6i7jcy8-cpplint-2.0.2",
               "default": true
             },
             {
               "name": "dist",
-              "path": "/nix/store/182lm1cw8ivk87d7313y6splsd9y7gkg-cpplint-2.0.2-dist"
+              "path": "/nix/store/pvy3ld0g8niw1vd28ypjhcm7ir67mffh-cpplint-2.0.2-dist"
             }
           ],
-          "store_path": "/nix/store/8zcvfkbngakvd90611rgb42d3sxyy67b-cpplint-2.0.2"
+          "store_path": "/nix/store/lz8hhjga6jq633fi5d9zx5igp6i7jcy8-cpplint-2.0.2"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ymd9r3bq2hzs5adx5mjkms00nabf4m8c-cpplint-2.0.2",
+              "path": "/nix/store/sb3v461kvyk1ar82584kwxw2bxhkfqf1-cpplint-2.0.2",
               "default": true
             },
             {
               "name": "dist",
-              "path": "/nix/store/n3p6ykrrpmq3jablbjvw6xfb3zskiyp8-cpplint-2.0.2-dist"
+              "path": "/nix/store/rk9rz700cpzxlsjnjkkr3ksxzylxqyk1-cpplint-2.0.2-dist"
             }
           ],
-          "store_path": "/nix/store/ymd9r3bq2hzs5adx5mjkms00nabf4m8c-cpplint-2.0.2"
+          "store_path": "/nix/store/sb3v461kvyk1ar82584kwxw2bxhkfqf1-cpplint-2.0.2"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/jjxzgwmhw7bk8lxjypv0wp6kyrkxd6nc-cpplint-2.0.2",
+              "path": "/nix/store/lbhva6s92qfjavjrss2ya4a0zbj1m3lz-cpplint-2.0.2",
               "default": true
             },
             {
               "name": "dist",
-              "path": "/nix/store/8k2h87vm1cmhcg1jig0v151xh5xk3fki-cpplint-2.0.2-dist"
+              "path": "/nix/store/k6kgicad5l64zwyazyf48xpvx5bp4m2v-cpplint-2.0.2-dist"
             }
           ],
-          "store_path": "/nix/store/jjxzgwmhw7bk8lxjypv0wp6kyrkxd6nc-cpplint-2.0.2"
+          "store_path": "/nix/store/lbhva6s92qfjavjrss2ya4a0zbj1m3lz-cpplint-2.0.2"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/wknb8m7h5f0z8i3liqfy23f5rfl7bjrc-cpplint-2.0.2",
+              "path": "/nix/store/4496zqjpx68xqs7h72ijzris09jphk21-cpplint-2.0.2",
               "default": true
             },
             {
               "name": "dist",
-              "path": "/nix/store/fxnizv1jgir7idq56lwv2qz1xv862p5r-cpplint-2.0.2-dist"
+              "path": "/nix/store/wgaq6nw9d2as2wax90zalvg8ph16lq6w-cpplint-2.0.2-dist"
             }
           ],
-          "store_path": "/nix/store/wknb8m7h5f0z8i3liqfy23f5rfl7bjrc-cpplint-2.0.2"
+          "store_path": "/nix/store/4496zqjpx68xqs7h72ijzris09jphk21-cpplint-2.0.2"
         }
       }
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "last_modified": "2026-02-11T21:01:36Z",
-      "resolved": "github:NixOS/nixpkgs/2343bbb58f99267223bc2aac4fc9ea301a155a16?lastModified=1770843696&narHash=sha256-LovWTGDwXhkfCOmbgLVA10bvsi%2FP8eDDpRudgk68HA8%3D"
+      "last_modified": "2026-05-29T05:01:12Z",
+      "resolved": "github:NixOS/nixpkgs/e9a7635a57597d9754eccebdfc7045e6c8600e6b?lastModified=1780030872&narHash=sha256-u6WU%2Fyd%2Fo8iYQrHX3RAwO1hYa3LkoSL%2BWNQD0rJfJZQ%3D"
     },
     "python3Packages.pip": {
       "resolved": "github:NixOS/nixpkgs/2343bbb58f99267223bc2aac4fc9ea301a155a16?narHash=sha256-LovWTGDwXhkfCOmbgLVA10bvsi%2FP8eDDpRudgk68HA8%3D#python3Packages.pip",

--- a/platformio.ini
+++ b/platformio.ini
@@ -70,6 +70,7 @@ lib_ldf_mode = off
 platform = espressif32
 board = esp32dev
 framework = arduino
+build_flags = ${env.build_flags} -DLED_BUILTIN=2
 
 [env:sparkfun_samd21_dev_usb]
 platform = atmelsam


### PR DESCRIPTION
Run `make ci-act` to run the matrix test from `.github/workflows/test.yml` locally. This simplifies the Makefile where a similar functionality was implemented.