### PR TITLE
feat: Pause and Resume effects and groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           for example in $(find examples -maxdepth 2 -name '*.ino' -printf '%P\n' | cut -d/ -f1 | sort -u); do
             extra_opts=()
             [[ "$example" == "morse" ]] && extra_opts+=(--lib=examples/morse)
-            [[ "$example" == "last_brightness" ]] && extra_opts+=(--project-option 'lib_deps = arduinogetstarted/ezButton@1.0.6')
+            [[ "$example" == "last_brightness" || "$example" == "pause_resume" ]] && extra_opts+=(--project-option 'lib_deps = arduinogetstarted/ezButton@1.0.6')
             echo "::group::$example"
             if pio ci --board="${{ matrix.board }}" --lib="src" \
                 "${extra_opts[@]}" ${{ matrix.extra_flags }} \

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ void loop() {
     - [IsRunning](#isrunning)
     - [Reset](#reset)
     - [Immediate Stop](#immediate-stop)
+    - [Pause and Resume](#pause-and-resume)
   - [Misc functions](#misc-functions)
     - [Low active for inverted output](#low-active-for-inverted-output)
     - [Minimum- and Maximum brightness level](#minimum--and-maximum-brightness-level)
@@ -519,6 +520,34 @@ brightness level to `MinBrightness`.
 led.Stop(JLed::eStopMode::FULL_OFF);
 ```
 
+### Pause and Resume
+
+Call `Pause()` to freeze the current effect at its current brightness. While paused,
+`Update()` returns `true` but does not advance the effect or change the brightness output.
+Call `Resume()` to continue the effect from the exact point where it was paused. `IsPaused()`
+returns `true` while the effect is frozen.
+
+Pausing before an effect has started is valid: the effect will not start until
+`Resume()` is called.
+
+```c++
+auto led = JLed(9).Breathe(2000).Forever();
+
+void loop() {
+  if (buttonPressed()) {
+    if (led.IsPaused()) {
+      led.Resume();
+    } else {
+      led.Pause();
+    }
+  }
+  led.Update();
+}
+```
+
+`JLedGroup` also supports `Pause()` and `Resume()`, which propagate to all member LEDs so
+the entire group freezes and resumes in sync.
+
 ### Misc functions
 
 #### Low active for inverted output
@@ -889,6 +918,7 @@ Example sketches are provided in the [examples](examples/) directory.
 - [Simple User provided effect](examples/user_func)
 - [Morsecode example](examples/morse)
 - [Last brightness value example](examples/last_brightness)
+- [Pause and resume effect with a button](examples/pause_resume)
 - [Custom HAL example](examples/custom_hal)
 - [Custom PCA9685 HAL](https://github.com/jandelgado/jled-pca9685-hal)
 - [Dynamically switch sequences](https://github.com/jandelgado/jled-example-switch-sequence)

--- a/README.md
+++ b/README.md
@@ -81,13 +81,12 @@ void loop() {
     - [IsRunning](#isrunning)
     - [Reset](#reset)
     - [Immediate Stop](#immediate-stop)
-    - [Pause and Resume](#pause-and-resume)
+  - [Pause and Resume](#pause-and-resume)
   - [Misc functions](#misc-functions)
     - [Low active for inverted output](#low-active-for-inverted-output)
     - [Minimum- and Maximum brightness level](#minimum--and-maximum-brightness-level)
   - [Controlling a group of LEDs](#controlling-a-group-of-leds)
     - [JLedRefGroup, pointer-based groups for named LED objects](#jledrefgroup-pointer-based-groups-for-named-led-objects)
-    - [JLedSequence to JLedGroup migration](#jledsequence-to-jledgroup-migration)
 - [Framework notes](#framework-notes)
 - [Platform notes](#platform-notes)
   - [Resolution and the `Brightness` type](#resolution-and-the-brightness-type)
@@ -106,6 +105,9 @@ void loop() {
   - [Support new hardware](#support-new-hardware)
 - [Unit tests](#unit-tests)
 - [Contributing](#contributing)
+- [JLed 5.0 migration guide](#jled-50-migration-guide)
+  - [`eStopMode` renamed to `eIdleMode`](#estopmode-renamed-to-eidlemode)
+  - [JLedSequence to JLedGroup migration](#jledsequence-to-jledgroup-migration)
 - [FAQ](#faq)
   - [How do I check if a JLed object is still being updated?](#how-do-i-check-if-a-jled-object-is-still-being-updated)
   - [How do I restart an effect?](#how-do-i-restart-an-effect)
@@ -662,36 +664,6 @@ applies the implicit conversion per element.
 > **Lifetime:** LED objects must outlive the `JLedRef` / `JLedRefGroup` that
 > references them. Do not create `JLedRef` from temporaries.
 
-#### `eStopMode` renamed to `eIdleMode`
-
-`eStopMode` has been renamed to `eIdleMode` and moved to the `jled` namespace.
-The same enum is now shared by `Stop()` and `Pause()`:
-
-```cpp
-// before
-led.Stop(JLed::eStopMode::KEEP_CURRENT);
-
-// after
-led.Stop(jled::eIdleMode::KEEP_CURRENT);
-```
-
-#### JLedSequence to JLedGroup migration
-
-`JLedSequence` is removed. Replace `JLed leds[]` with `JLedAny leds[]` and use the
-`JLedGroup` factory methods:
-
-```cpp
-// before
-JLed leds[] = {JLed(4).Blink(500, 500), JLed(5).Breathe(1000)};
-JLedSequence seq(JLedSequence::eMode::PARALLEL, leds);   // parallel
-JLedSequence seq(JLedSequence::eMode::SEQUENCE, leds);   // sequential
-
-// after
-JLedAny leds[] = {JLed(4).Blink(500, 500), JLed(5).Breathe(1000)};
-auto seq = JLedGroup::Parallel(leds);    // parallel
-auto seq = JLedGroup::Sequential(leds);  // sequential
-```
-
 ## Framework notes
 
 JLed supports the Arduino and [mbed](https://www.mbed.org) frameworks. When
@@ -987,6 +959,46 @@ the host-based provided unit tests [is provided here](test/README.md).
   provided [settings](.clang-format)
 - commit changes
 - submit a PR
+
+## JLed 5.0 migration guide
+
+JLed 5.0 introduced some breaking changes in the public APIs. Here is how to update
+your code to keep on running with JLed 5.0.
+
+#### `eStopMode` renamed to `eIdleMode`
+
+`JLed::eStopMode` has been renamed to `eIdleMode` and moved to the `jled` namespace.
+The same enum is shared by `Stop()` and the new `Pause()` functionality:
+
+```cpp
+// before
+led.Stop(JLed::eStopMode::KEEP_CURRENT);
+
+// after
+led.Stop(jled::eIdleMode::KEEP_CURRENT);
+```
+
+Reason: otherwise we would have separate `eStopMode` enums for `JLed`, `JLedHD` etc.
+classes, bloating the code.
+
+#### JLedSequence to JLedGroup migration
+
+In JLed 5.0 `JLedSequence` is replaced by `JLedGroup`. In your old code, replace `JLed leds[]` with
+`JLedAny leds[]` and use the `JLedGroup` factory methods:
+
+```cpp
+// before
+JLed leds[] = {JLed(4).Blink(500, 500), JLed(5).Breathe(1000)};
+JLedSequence seq(JLedSequence::eMode::PARALLEL, leds);   // parallel
+JLedSequence seq(JLedSequence::eMode::SEQUENCE, leds);   // sequential
+
+// after
+JLedAny leds[] = {JLed(4).Blink(500, 500), JLed(5).Breathe(1000)};
+auto seq = JLedGroup::Parallel(leds);    // parallel
+auto seq = JLedGroup::Sequential(leds);  // sequential
+```
+
+Reason: `JLedGroup` is a more capable replacement that supports mixing different LED types, nesting groups inside other groups, and applying repeat and pause/resume control to the whole group at once. The parallel and sequential modes are now explicit at the point of creation.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -662,6 +662,19 @@ applies the implicit conversion per element.
 > **Lifetime:** LED objects must outlive the `JLedRef` / `JLedRefGroup` that
 > references them. Do not create `JLedRef` from temporaries.
 
+#### `eStopMode` renamed to `eIdleMode`
+
+`eStopMode` has been renamed to `eIdleMode` and moved to the `jled` namespace.
+The same enum is now shared by `Stop()` and `Pause()`:
+
+```cpp
+// before
+led.Stop(JLed::eStopMode::KEEP_CURRENT);
+
+// after
+led.Stop(jled::eIdleMode::KEEP_CURRENT);
+```
+
 #### JLedSequence to JLedGroup migration
 
 `JLedSequence` is removed. Replace `JLed leds[]` with `JLedAny leds[]` and use the

--- a/examples/last_brightness/last_brightness.ino
+++ b/examples/last_brightness/last_brightness.ino
@@ -30,7 +30,7 @@ void loop() {
     if (button.isPressed()) {
         // when the button is pressed, stop the effect on led, but keep the LED
         // on with it's current brightness ...
-        led.Stop(JLed::KEEP_CURRENT);
+        led.Stop(jled::eIdleMode::KEEP_CURRENT);
     } else if (button.isReleased()) {
         // when the button is released, fade from the last brightness to 0
         led = JLed(LED_PIN).Fade(lastBrightness, 0, 1000);

--- a/examples/pause_resume/pause_resume.ino
+++ b/examples/pause_resume/pause_resume.ino
@@ -1,0 +1,33 @@
+// Toggle pause and resume of a breathing LED effect with a button press.
+// Each press freezes the LED at its current brightness; the next press
+// continues the effect from that exact point.
+//
+// dependency: arduinogetstarted/ezButton@1.0.6 to control the button
+//
+// Copyright 2026 by Jan Delgado. All rights reserved.
+// https://github.com/jandelgado/jled
+//
+#include <ezButton.h>  // arduinogetstarted/ezButton@1.0.6
+#include <jled.h>
+
+constexpr auto LED_PIN = 16;
+constexpr auto BUTTON_PIN = 18;
+
+auto button = ezButton(BUTTON_PIN);
+auto led = JLed(LED_PIN).Breathe(2000).Forever();
+
+void setup() {}
+
+void loop() {
+    button.loop();
+
+    if (button.isPressed()) {
+        if (led.IsPaused()) {
+            led.Resume();
+        } else {
+            led.Pause();
+        }
+    }
+
+    led.Update();
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,7 @@ src_dir = examples/hello
 ;src_dir = examples/hires
 ;src_dir = examples/simple_on
 ;src_dir = examples/last_brightness
+;src_dir = examples/pause_resume
 ;src_dir = examples/user_func
 ;src_dir = examples/sequence
 ;src_dir = examples/group

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -464,6 +464,7 @@ class TJLed : public JLedBase {
     Derived& Reset() {
         time_start_ = 0;
         last_update_time_ = 0;
+        bPaused_ = false;
         state_ = ST_INIT;
         return static_cast<Derived&>(*this);
     }

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -679,6 +679,8 @@ class TJLedGroup {
     bool Update(uint32_t t);
     void Reset();
     void Stop();
+    void Pause(uint32_t t);
+    void Resume(uint32_t t);
 
     TJLedGroup(eMode mode, AnyType* leds, size_t n)
         : mode_(mode), leds_(leds), n_(static_cast<uint8_t>(n > 255 ? 255 : n)) {
@@ -714,6 +716,8 @@ struct TJLedAny {
         bool (*update)(void*, uint32_t);
         void (*reset)(void*);
         void (*stop)(void*);
+        void (*pause)(void*, uint32_t);
+        void (*resume)(void*, uint32_t);
         void (*copy)(void* dst, const void* src);
         void (*dtor)(void*);
     };
@@ -727,6 +731,8 @@ struct TJLedAny {
             [](void* p, uint32_t t) -> bool { return static_cast<T*>(p)->Update(t); },
             [](void* p) { static_cast<T*>(p)->Reset(); },
             [](void* p) { static_cast<T*>(p)->Stop(); },
+            [](void* p, uint32_t t) { static_cast<T*>(p)->Pause(t); },
+            [](void* p, uint32_t t) { static_cast<T*>(p)->Resume(t); },
             [](void* dst, const void* src) {
                 new (dst) T(*static_cast<const T*>(src));
             },
@@ -773,6 +779,8 @@ struct TJLedAny {
     bool Update(uint32_t t) { return vtable_->update(buf_, t); }
     void Reset()            { vtable_->reset(buf_); }
     void Stop()             { vtable_->stop(buf_); }
+    void Pause(uint32_t t)  { vtable_->pause(buf_, t); }
+    void Resume(uint32_t t) { vtable_->resume(buf_, t); }
 };
 
 // TJLedRef is a non-owning type-erased reference to any LED or group.
@@ -784,6 +792,8 @@ class TJLedRef {
         bool (*update)(void*, uint32_t);
         void (*reset)(void*);
         void (*stop)(void*);
+        void (*pause)(void*, uint32_t);
+        void (*resume)(void*, uint32_t);
     };
     void*          obj_;
     const Vtable*  vtable_;
@@ -793,7 +803,9 @@ class TJLedRef {
         static const Vtable kVt = {
             [](void* p, uint32_t t) -> bool { return static_cast<T*>(p)->Update(t); },
             [](void* p) { static_cast<T*>(p)->Reset(); },
-            [](void* p) { static_cast<T*>(p)->Stop(); }
+            [](void* p) { static_cast<T*>(p)->Stop(); },
+            [](void* p, uint32_t t) { static_cast<T*>(p)->Pause(t); },
+            [](void* p, uint32_t t) { static_cast<T*>(p)->Resume(t); }
         };
         return &kVt;
     }
@@ -813,6 +825,8 @@ class TJLedRef {
     bool Update(uint32_t t) { return vtable_->update(obj_, t); }
     void Reset()            { vtable_->reset(obj_); }
     void Stop()             { vtable_->stop(obj_); }
+    void Pause(uint32_t t)  { vtable_->pause(obj_, t); }
+    void Resume(uint32_t t) { vtable_->resume(obj_, t); }
 };
 
 // TJLedGroup method bodies, defined after TJLedAny is complete.
@@ -883,6 +897,17 @@ void TJLedGroup<Clock, AnyType>::Stop() {
     for (auto i = 0u; i < n_; i++) {
         leds_[i].Stop();
     }
+}
+
+// Pause and Resume are stubbed here; Task 3 will implement the fan-out logic.
+template <typename Clock, typename AnyType>
+void TJLedGroup<Clock, AnyType>::Pause(uint32_t t) {
+    (void)t;
+}
+
+template <typename Clock, typename AnyType>
+void TJLedGroup<Clock, AnyType>::Resume(uint32_t t) {
+    (void)t;
 }
 
 };  // namespace jled

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -436,6 +436,7 @@ class TJLed : public JLedBase {
                       : minBrightness_);
         }
         state_ = ST_STOPPED;
+        bPaused_ = false;
         return static_cast<Derived&>(*this);
     }
 

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -441,7 +441,7 @@ class TJLed : public JLedBase {
 
     bool IsRunning() const { return state_ != ST_STOPPED; }
 
-    void Pause() { Pause(Clock::millis()); }
+    void Pause(eIdleMode mode = eIdleMode::FULL_OFF) { Pause(Clock::millis(), mode); }
     void Resume() { Resume(Clock::millis()); }
 
     bool IsPaused() const { return bPaused_; }
@@ -549,9 +549,14 @@ class TJLed : public JLedBase {
     }
 
  protected:
-    void Pause(uint32_t t) {
+    void Pause(uint32_t t, eIdleMode mode = eIdleMode::FULL_OFF) {
         if (bPaused_ || state_ == ST_STOPPED) return;
         bPaused_ = true;
+        if (mode != eIdleMode::KEEP_CURRENT) {
+            Write(mode == eIdleMode::FULL_OFF
+                      ? BrightnessTraits<Brightness>::kZeroBrightness
+                      : minBrightness_);
+        }
         if (state_ != ST_INIT)
             time_start_ = t - time_start_;  // encode elapsed_so_far in place
         // ST_INIT: time_start_ is 0 and not yet meaningful; Update() resets it on resume
@@ -685,7 +690,7 @@ class TJLedGroup {
     bool Update(uint32_t t);
     void Reset();
     void Stop();
-    void Pause();
+    void Pause(eIdleMode mode = eIdleMode::FULL_OFF);
     void Resume();
 
     TJLedGroup(eMode mode, AnyType* leds, size_t n)
@@ -693,7 +698,7 @@ class TJLedGroup {
     }
 
  protected:
-    void Pause(uint32_t t);
+    void Pause(uint32_t t, eIdleMode mode = eIdleMode::FULL_OFF);
     void Resume(uint32_t t);
 
     template <size_t N> friend struct TJLedAny;
@@ -729,7 +734,7 @@ struct TJLedAny {
         bool (*update)(void*, uint32_t);
         void (*reset)(void*);
         void (*stop)(void*);
-        void (*pause)(void*, uint32_t);
+        void (*pause)(void*, uint32_t, eIdleMode);
         void (*resume)(void*, uint32_t);
         void (*copy)(void* dst, const void* src);
         void (*dtor)(void*);
@@ -744,7 +749,7 @@ struct TJLedAny {
             [](void* p, uint32_t t) -> bool { return static_cast<T*>(p)->Update(t); },
             [](void* p) { static_cast<T*>(p)->Reset(); },
             [](void* p) { static_cast<T*>(p)->Stop(); },
-            [](void* p, uint32_t t) { static_cast<T*>(p)->Pause(t); },
+            [](void* p, uint32_t t, eIdleMode m) { static_cast<T*>(p)->Pause(t, m); },
             [](void* p, uint32_t t) { static_cast<T*>(p)->Resume(t); },
             [](void* dst, const void* src) {
                 new (dst) T(*static_cast<const T*>(src));
@@ -793,7 +798,9 @@ struct TJLedAny {
     bool Update(uint32_t t) { return vtable_->update(buf_, t); }
     void Reset()            { vtable_->reset(buf_); }
     void Stop()             { vtable_->stop(buf_); }
-    void Pause(uint32_t t)  { vtable_->pause(buf_, t); }
+    void Pause(uint32_t t, eIdleMode mode = eIdleMode::FULL_OFF) {
+        vtable_->pause(buf_, t, mode);
+    }
     void Resume(uint32_t t) { vtable_->resume(buf_, t); }
 
     template <typename Clock, typename AnyType> friend class TJLedGroup;
@@ -808,7 +815,7 @@ class TJLedRef {
         bool (*update)(void*, uint32_t);
         void (*reset)(void*);
         void (*stop)(void*);
-        void (*pause)(void*, uint32_t);
+        void (*pause)(void*, uint32_t, eIdleMode);
         void (*resume)(void*, uint32_t);
     };
     void*          obj_;
@@ -820,7 +827,7 @@ class TJLedRef {
             [](void* p, uint32_t t) -> bool { return static_cast<T*>(p)->Update(t); },
             [](void* p) { static_cast<T*>(p)->Reset(); },
             [](void* p) { static_cast<T*>(p)->Stop(); },
-            [](void* p, uint32_t t) { static_cast<T*>(p)->Pause(t); },
+            [](void* p, uint32_t t, eIdleMode m) { static_cast<T*>(p)->Pause(t, m); },
             [](void* p, uint32_t t) { static_cast<T*>(p)->Resume(t); }
         };
         return &kVt;
@@ -842,7 +849,9 @@ class TJLedRef {
     bool Update(uint32_t t) { return vtable_->update(obj_, t); }
     void Reset()            { vtable_->reset(obj_); }
     void Stop()             { vtable_->stop(obj_); }
-    void Pause(uint32_t t)  { vtable_->pause(obj_, t); }
+    void Pause(uint32_t t, eIdleMode mode = eIdleMode::FULL_OFF) {
+        vtable_->pause(obj_, t, mode);
+    }
     void Resume(uint32_t t) { vtable_->resume(obj_, t); }
 
     template <typename Clock, typename AnyType> friend class TJLedGroup;
@@ -919,13 +928,13 @@ void TJLedGroup<Clock, AnyType>::Stop() {
 }
 
 template <typename Clock, typename AnyType>
-void TJLedGroup<Clock, AnyType>::Pause(uint32_t t) {
-    for (auto i = 0u; i < n_; i++) leds_[i].Pause(t);
+void TJLedGroup<Clock, AnyType>::Pause(uint32_t t, eIdleMode mode) {
+    for (auto i = 0u; i < n_; i++) leds_[i].Pause(t, mode);
 }
 
 template <typename Clock, typename AnyType>
-void TJLedGroup<Clock, AnyType>::Pause() {
-    Pause(Clock::millis());
+void TJLedGroup<Clock, AnyType>::Pause(eIdleMode mode) {
+    Pause(Clock::millis(), mode);
 }
 
 template <typename Clock, typename AnyType>

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -243,6 +243,8 @@ struct EvalStorage {
 // std::is_base_of without requiring a common virtual interface.
 class JLedBase {};
 
+enum class eIdleMode { TO_MIN_BRIGHTNESS = 0, FULL_OFF, KEEP_CURRENT };
+
 template <typename Hal, typename Clock, typename Brightness, typename Derived>
 class TJLed : public JLedBase {
  protected:
@@ -427,10 +429,9 @@ class TJLed : public JLedBase {
 
     // Stop current effect and turn LED immeadiately off. Further calls to
     // Update() will have no effect.
-    enum eStopMode { TO_MIN_BRIGHTNESS = 0, FULL_OFF, KEEP_CURRENT };
-    Derived& Stop(eStopMode mode = eStopMode::TO_MIN_BRIGHTNESS) {
-        if (mode != eStopMode::KEEP_CURRENT) {
-            Write(mode == eStopMode::FULL_OFF
+    Derived& Stop(eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS) {
+        if (mode != eIdleMode::KEEP_CURRENT) {
+            Write(mode == eIdleMode::FULL_OFF
                       ? BrightnessTraits<Brightness>::kZeroBrightness
                       : minBrightness_);
         }
@@ -440,22 +441,7 @@ class TJLed : public JLedBase {
 
     bool IsRunning() const { return state_ != ST_STOPPED; }
 
-    void Pause(uint32_t t) {
-        if (bPaused_ || state_ == ST_STOPPED) return;
-        bPaused_ = true;
-        if (state_ != ST_INIT)
-            time_start_ = t - time_start_;  // encode elapsed_so_far in place
-        // ST_INIT: time_start_ is 0 and not yet meaningful; Update() resets it on resume
-    }
     void Pause() { Pause(Clock::millis()); }
-
-    void Resume(uint32_t t) {
-        if (!bPaused_) return;
-        bPaused_ = false;
-        if (state_ != ST_INIT)
-            time_start_ = t - time_start_;  // restore epoch: t - elapsed_so_far
-        // ST_INIT: Update() will set time_start_ fresh on next call
-    }
     void Resume() { Resume(Clock::millis()); }
 
     bool IsPaused() const { return bPaused_; }
@@ -563,12 +549,31 @@ class TJLed : public JLedBase {
     }
 
  protected:
+    void Pause(uint32_t t) {
+        if (bPaused_ || state_ == ST_STOPPED) return;
+        bPaused_ = true;
+        if (state_ != ST_INIT)
+            time_start_ = t - time_start_;  // encode elapsed_so_far in place
+        // ST_INIT: time_start_ is 0 and not yet meaningful; Update() resets it on resume
+    }
+
+    void Resume(uint32_t t) {
+        if (!bPaused_) return;
+        bPaused_ = false;
+        if (state_ != ST_INIT)
+            time_start_ = t - time_start_;  // restore epoch: t - elapsed_so_far
+        // ST_INIT: Update() will set time_start_ fresh on next call
+    }
+
     // test if time stored in last_update_time_ differs from provided timestamp.
     bool inline timeChangedSinceLastUpdate(uint32_t now) {
         return (now & 255) != last_update_time_;
     }
 
     void trackLastUpdateTime(uint32_t t) { last_update_time_ = (t & 255); }
+
+    template <size_t N> friend struct TJLedAny;
+    friend class TJLedRef;
 
  public:
     // Number of bits used to control brightness with Min/MaxBrightness().
@@ -680,14 +685,19 @@ class TJLedGroup {
     bool Update(uint32_t t);
     void Reset();
     void Stop();
-    void Pause(uint32_t t);
     void Pause();
-    void Resume(uint32_t t);
     void Resume();
 
     TJLedGroup(eMode mode, AnyType* leds, size_t n)
         : mode_(mode), leds_(leds), n_(static_cast<uint8_t>(n > 255 ? 255 : n)) {
     }
+
+ protected:
+    void Pause(uint32_t t);
+    void Resume(uint32_t t);
+
+    template <size_t N> friend struct TJLedAny;
+    friend class TJLedRef;
 
  private:
     bool UpdateParallel(uint32_t t);
@@ -779,11 +789,14 @@ struct TJLedAny {
 
     ~TJLedAny() { vtable_->dtor(buf_); }
 
+ protected:
     bool Update(uint32_t t) { return vtable_->update(buf_, t); }
     void Reset()            { vtable_->reset(buf_); }
     void Stop()             { vtable_->stop(buf_); }
     void Pause(uint32_t t)  { vtable_->pause(buf_, t); }
     void Resume(uint32_t t) { vtable_->resume(buf_, t); }
+
+    template <typename Clock, typename AnyType> friend class TJLedGroup;
 };
 
 // TJLedRef is a non-owning type-erased reference to any LED or group.
@@ -825,11 +838,14 @@ class TJLedRef {
     TJLedRef(TJLedGroup<Clock, AnyType>* ptr)  // NOLINT
         : obj_(ptr), vtable_(VtableFor<TJLedGroup<Clock, AnyType>>()) {}
 
+ protected:
     bool Update(uint32_t t) { return vtable_->update(obj_, t); }
     void Reset()            { vtable_->reset(obj_); }
     void Stop()             { vtable_->stop(obj_); }
     void Pause(uint32_t t)  { vtable_->pause(obj_, t); }
     void Resume(uint32_t t) { vtable_->resume(obj_, t); }
+
+    template <typename Clock, typename AnyType> friend class TJLedGroup;
 };
 
 // TJLedGroup method bodies, defined after TJLedAny is complete.

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -592,6 +592,13 @@ class TJLed : public JLedBase {
                            ST_RUNNING = 2,
                            ST_IN_DELAY_AFTER_PHASE = 3 };
 
+    // state_ and bPaused_ model two orthogonal dimensions. state_ tracks the
+    // progression through the effect (init -> running <-> delay-after ->
+    // stopped), while bPaused_ records whether that progression is currently
+    // frozen. Keeping pause as a separate flag preserves the underlying state_
+    // across a pause/resume cycle (needed to continue where we left off) and
+    // avoids the combinatorial blow-up of state_ x paused that a dedicated
+    // ST_PAUSED state would require (ST_INIT_PAUSED, ST_RUNNING_PAUSED, ...).
     uint8_t state_ : 2;  // stored as uint8_t to avoid GCC warning about enum bit-field signedness
     uint8_t bLowActive_ : 1;
     uint8_t bPaused_ : 1;

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -268,6 +268,7 @@ class TJLed : public JLedBase {
         : hal_{hal},
           state_{ST_INIT},
           bLowActive_{false},
+          bPaused_{false},
           minBrightness_{BrightnessTraits<Brightness>::kZeroBrightness},
           maxBrightness_{BrightnessTraits<Brightness>::kFullBrightness} {}
 
@@ -275,6 +276,7 @@ class TJLed : public JLedBase {
         : hal_{pin},
           state_{ST_INIT},
           bLowActive_{false},
+          bPaused_{false},
           minBrightness_{BrightnessTraits<Brightness>::kZeroBrightness},
           maxBrightness_{BrightnessTraits<Brightness>::kFullBrightness} {}
 
@@ -283,6 +285,7 @@ class TJLed : public JLedBase {
     Derived& operator=(const TJLed<Hal, Clock, Brightness, Derived>& rLed) {
         state_ = rLed.state_;
         bLowActive_ = rLed.bLowActive_;
+        bPaused_ = rLed.bPaused_;
         minBrightness_ = rLed.minBrightness_;
         maxBrightness_ = rLed.maxBrightness_;
         num_repetitions_ = rLed.num_repetitions_;
@@ -437,6 +440,26 @@ class TJLed : public JLedBase {
 
     bool IsRunning() const { return state_ != ST_STOPPED; }
 
+    void Pause(uint32_t t) {
+        if (bPaused_ || state_ == ST_STOPPED) return;
+        bPaused_ = true;
+        if (state_ != ST_INIT)
+            time_start_ = t - time_start_;  // encode elapsed_so_far in place
+        // ST_INIT: time_start_ is 0 and not yet meaningful; Update() resets it on resume
+    }
+    void Pause() { Pause(Clock::millis()); }
+
+    void Resume(uint32_t t) {
+        if (!bPaused_) return;
+        bPaused_ = false;
+        if (state_ != ST_INIT)
+            time_start_ = t - time_start_;  // restore epoch: t - elapsed_so_far
+        // ST_INIT: Update() will set time_start_ fresh on next call
+    }
+    void Resume() { Resume(Clock::millis()); }
+
+    bool IsPaused() const { return bPaused_; }
+
     // Reset to inital state
     Derived& Reset() {
         time_start_ = 0;
@@ -483,6 +506,7 @@ class TJLed : public JLedBase {
     }
 
     bool Update(uint32_t t, int16_t* pLast = nullptr) {
+        if (bPaused_) return true;
         if (state_ == ST_STOPPED || !eval_storage_.IsSet()) return false;
 
         if (state_ == ST_INIT) {
@@ -558,6 +582,7 @@ class TJLed : public JLedBase {
 
     uint8_t state_ : 2;  // stored as uint8_t to avoid GCC warning about enum bit-field signedness
     uint8_t bLowActive_ : 1;
+    uint8_t bPaused_ : 1;
     Brightness minBrightness_;
     Brightness maxBrightness_;
 

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -680,7 +680,9 @@ class TJLedGroup {
     void Reset();
     void Stop();
     void Pause(uint32_t t);
+    void Pause();
     void Resume(uint32_t t);
+    void Resume();
 
     TJLedGroup(eMode mode, AnyType* leds, size_t n)
         : mode_(mode), leds_(leds), n_(static_cast<uint8_t>(n > 255 ? 255 : n)) {
@@ -899,15 +901,24 @@ void TJLedGroup<Clock, AnyType>::Stop() {
     }
 }
 
-// Pause and Resume are stubbed here; Task 3 will implement the fan-out logic.
 template <typename Clock, typename AnyType>
 void TJLedGroup<Clock, AnyType>::Pause(uint32_t t) {
-    (void)t;
+    for (auto i = 0u; i < n_; i++) leds_[i].Pause(t);
+}
+
+template <typename Clock, typename AnyType>
+void TJLedGroup<Clock, AnyType>::Pause() {
+    Pause(Clock::millis());
 }
 
 template <typename Clock, typename AnyType>
 void TJLedGroup<Clock, AnyType>::Resume(uint32_t t) {
-    (void)t;
+    for (auto i = 0u; i < n_; i++) leds_[i].Resume(t);
+}
+
+template <typename Clock, typename AnyType>
+void TJLedGroup<Clock, AnyType>::Resume() {
+    Resume(Clock::millis());
 }
 
 };  // namespace jled

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -517,6 +517,32 @@ TEST_CASE("Stop(KEEP_CURRENT) keeps the last brightness level", "[jled]") {
     CHECK(130 == static_cast<int>(jled.GetHal().Value()));
 }
 
+TEST_CASE("Pause(FULL_OFF) sets brightness to 0", "[jled]") {
+    auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{100, 0});
+    TestJLed jled = TestJLed(10).UserFunc(&eval).MinBrightness(50);
+
+    jled.Update();
+    REQUIRE(130 ==
+            static_cast<int>(jled.GetHal().Value()));  // 100 scaled to [50,255]
+
+    TimeMock::set_millis(1);
+    jled.Pause(jled::eIdleMode::FULL_OFF);
+    CHECK(0 == static_cast<int>(jled.GetHal().Value()));
+}
+
+TEST_CASE("Pause(KEEP_CURRENT) keeps the last brightness level", "[jled]") {
+    auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{100, 0});
+    TestJLed jled = TestJLed(10).UserFunc(&eval).MinBrightness(50);
+
+    jled.Update();
+    REQUIRE(130 ==
+            static_cast<int>(jled.GetHal().Value()));  // 100 scaled to [50,255]
+
+    TimeMock::set_millis(1);
+    jled.Pause(jled::eIdleMode::KEEP_CURRENT);
+    CHECK(130 == static_cast<int>(jled.GetHal().Value()));
+}
+
 TEST_CASE("LowActive() inverts signal", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{0, 255});
     TestJLed jled = TestJLed(1).UserFunc(&eval).LowActive();
@@ -782,7 +808,7 @@ TEST_CASE("lerp8by8 interpolates a byte into the given interval",
     CHECK(200 == (int)(jled::lerp8by8(255, 100, 200)));
 }
 
-TEST_CASE("Pause() during ST_RUNNING freezes brightness", "[jled]") {
+TEST_CASE("Pause() during ST_RUNNING turns LED off (FULL_OFF default)", "[jled]") {
     TestJLed jled(HalMock(1));
     jled.Blink(4, 4);  // on for t_cycle=0..3, off for t_cycle=4..7, done at t=8
 
@@ -797,9 +823,9 @@ TEST_CASE("Pause() during ST_RUNNING freezes brightness", "[jled]") {
 
     // Further updates must not change brightness and must return true
     CHECK(jled.Update(3));
-    CHECK(jled.GetHal().Value() == brightness_at_pause);
+    CHECK(jled.GetHal().Value() == 0);
     CHECK(jled.Update(100));
-    CHECK(jled.GetHal().Value() == brightness_at_pause);
+    CHECK(jled.GetHal().Value() == 0);
 }
 
 TEST_CASE("Resume() continues effect from freeze point", "[jled]") {

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -954,3 +954,18 @@ TEST_CASE("Reset() clears pause state", "[jled]") {
     CHECK(jled.Update(10, nullptr));
     CHECK(jled.GetHal().Value() == 255);  // t_cycle=0, on-phase
 }
+
+TEST_CASE("Stop() clears pause state", "[jled]") {
+    TestJLed jled(HalMock(1));
+    jled.Blink(4, 4);
+    jled.Update(0, nullptr);
+    TimeMock::set_millis(1);
+    jled.Pause();
+    REQUIRE(jled.IsPaused());
+
+    jled.Stop();
+    // Stopping a paused LED must leave it stopped, not paused.
+    CHECK_FALSE(jled.IsPaused());
+    // Stopped LED reports not-running, even though it was paused before.
+    CHECK_FALSE(jled.Update(6));
+}

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -898,3 +898,18 @@ TEST_CASE("copy of paused JLed preserves pause state", "[jled]") {
     CHECK(copy.Update(51));
     CHECK(copy.GetHal().Value() == 255);
 }
+
+TEST_CASE("Reset() clears pause state", "[jled]") {
+    TestJLed jled(HalMock(1));
+    jled.Blink(4, 4);
+    jled.Update(0, nullptr);
+    jled.Pause(1);
+    CHECK(jled.IsPaused());
+
+    jled.Reset();
+    CHECK_FALSE(jled.IsPaused());
+
+    // After Reset, Update should start the effect normally
+    CHECK(jled.Update(10, nullptr));
+    CHECK(jled.GetHal().Value() == 255);  // t_cycle=0, on-phase
+}

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -543,6 +543,19 @@ TEST_CASE("Pause(KEEP_CURRENT) keeps the last brightness level", "[jled]") {
     CHECK(130 == static_cast<int>(jled.GetHal().Value()));
 }
 
+TEST_CASE("Pause(TO_MIN_BRIGHTNESS) sets brightness to minimum", "[jled]") {
+    auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{100, 0});
+    TestJLed jled = TestJLed(10).UserFunc(&eval).MinBrightness(50);
+
+    jled.Update();
+    REQUIRE(130 ==
+            static_cast<int>(jled.GetHal().Value()));  // 100 scaled to [50,255]
+
+    TimeMock::set_millis(1);
+    jled.Pause(jled::eIdleMode::TO_MIN_BRIGHTNESS);
+    CHECK(50 == static_cast<int>(jled.GetHal().Value()));
+}
+
 TEST_CASE("LowActive() inverts signal", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{0, 255});
     TestJLed jled = TestJLed(1).UserFunc(&eval).LowActive();

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -782,3 +782,119 @@ TEST_CASE("lerp8by8 interpolates a byte into the given interval",
     CHECK(200 == (int)(jled::lerp8by8(255, 100, 200)));
 }
 
+TEST_CASE("Pause() during ST_RUNNING freezes brightness", "[jled]") {
+    TestJLed jled(HalMock(1));
+    jled.Blink(4, 4);  // on for t_cycle=0..3, off for t_cycle=4..7, done at t=8
+
+    // Run to t=2 (mid-blink, brightness=255)
+    jled.Update(0, nullptr);
+    jled.Update(2);
+    const auto brightness_at_pause = jled.GetHal().Value();  // 255
+
+    jled.Pause(2);
+    CHECK(jled.IsPaused());
+
+    // Further updates must not change brightness and must return true
+    CHECK(jled.Update(3));
+    CHECK(jled.GetHal().Value() == brightness_at_pause);
+    CHECK(jled.Update(100));
+    CHECK(jled.GetHal().Value() == brightness_at_pause);
+}
+
+TEST_CASE("Resume() continues effect from freeze point", "[jled]") {
+    TestJLed jled(HalMock(1));
+    jled.Blink(4, 4);  // on=[0..3], off=[4..7], period=8
+
+    // Advance to t=2 (elapsed=2, on-phase)
+    jled.Update(0, nullptr);
+    jled.Update(2);
+
+    // Pause at t=2 (elapsed_so_far=2), resume at t=50
+    // After resume: effective epoch = 50-2 = 48
+    jled.Pause(2);
+    jled.Resume(50);
+    CHECK_FALSE(jled.IsPaused());
+
+    // At t=51: elapsed = 51-48 = 3 → t_cycle=3, on-phase → 255
+    CHECK(jled.Update(51));
+    CHECK(jled.GetHal().Value() == 255);
+
+    // At t=52: elapsed = 52-48 = 4 → t_cycle=4, off-phase → 0
+    CHECK(jled.Update(52));
+    CHECK(jled.GetHal().Value() == 0);
+}
+
+TEST_CASE("Pause() in ST_STOPPED is a no-op", "[jled]") {
+    TestJLed jled(HalMock(1));
+    jled.Blink(2, 2);
+    jled.Update(0, nullptr);
+    jled.Stop();
+    jled.Pause(5);
+    CHECK_FALSE(jled.IsPaused());
+    CHECK_FALSE(jled.Update(6));
+}
+
+TEST_CASE("Pause() in ST_INIT delays effect start until Resume()", "[jled]") {
+    TestJLed jled(HalMock(1));
+    jled.Blink(2, 2);  // on=[0,1], off=[2,3], period=4
+
+    jled.Pause(0);
+    CHECK(jled.IsPaused());
+
+    // Updates must not start the effect
+    CHECK(jled.Update(0, nullptr));
+    CHECK(jled.GetHal().Value() == 0);  // nothing written yet
+    CHECK(jled.Update(5));
+    CHECK(jled.GetHal().Value() == 0);
+
+    // After Resume the effect starts normally on next Update
+    jled.Resume(10);
+    CHECK_FALSE(jled.IsPaused());
+    CHECK(jled.Update(10));
+    CHECK(jled.GetHal().Value() == 255);  // t_cycle=0, on-phase
+}
+
+TEST_CASE("Pause() is idempotent", "[jled]") {
+    TestJLed jled(HalMock(1));
+    jled.Blink(4, 4);
+    jled.Update(0, nullptr);  // time_start_=0
+
+    jled.Pause(1);   // time_start_ = 1-0 = 1 (elapsed=1 encoded)
+    jled.Pause(99);  // second call — must be no-op, not re-encode
+    jled.Resume(50);  // time_start_ = 50-1 = 49 (epoch restored)
+
+    // At t=51: elapsed = 51-49 = 2 → on-phase → 255
+    CHECK(jled.Update(51));
+    CHECK(jled.GetHal().Value() == 255);
+}
+
+TEST_CASE("Resume() is idempotent", "[jled]") {
+    TestJLed jled(HalMock(1));
+    jled.Blink(4, 4);
+    jled.Update(0, nullptr);
+    jled.Pause(1);
+    jled.Resume(10);  // time_start_ = 10-1 = 9 (epoch)
+    jled.Resume(99);  // second call — must be no-op
+    CHECK_FALSE(jled.IsPaused());
+
+    // At t=11: elapsed = 11-9 = 2 → on-phase → 255
+    CHECK(jled.Update(11));
+    CHECK(jled.GetHal().Value() == 255);
+}
+
+TEST_CASE("copy of paused JLed preserves pause state", "[jled]") {
+    TestJLed jled(HalMock(1));
+    jled.Blink(4, 4);
+    jled.Update(0, nullptr);
+    jled.Update(2);
+    jled.Pause(2);  // time_start_ = 2-0 = 2 (elapsed=2 encoded)
+
+    TestJLed copy = jled;
+    CHECK(copy.IsPaused());
+
+    // Copy resumes correctly: time_start_ = 50-2 = 48 (epoch)
+    copy.Resume(50);
+    // At t=51: elapsed = 51-48 = 3 → on-phase → 255
+    CHECK(copy.Update(51));
+    CHECK(copy.GetHal().Value() == 255);
+}

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -501,7 +501,7 @@ TEST_CASE("Stop(FULL_OFF) sets the brightness to 0", "[jled]") {
     REQUIRE(130 ==
             static_cast<int>(jled.GetHal().Value()));  // 100 scaled to [50,255]
 
-    jled.Stop(TestJLed::eStopMode::FULL_OFF);
+    jled.Stop(jled::eIdleMode::FULL_OFF);
     CHECK(0 == static_cast<int>(jled.GetHal().Value()));
 }
 
@@ -513,7 +513,7 @@ TEST_CASE("Stop(KEEP_CURRENT) keeps the last brightness level", "[jled]") {
     REQUIRE(130 ==
             static_cast<int>(jled.GetHal().Value()));  // 100 scaled to [50,255]
 
-    jled.Stop(TestJLed::eStopMode::KEEP_CURRENT);
+    jled.Stop(jled::eIdleMode::KEEP_CURRENT);
     CHECK(130 == static_cast<int>(jled.GetHal().Value()));
 }
 
@@ -791,7 +791,8 @@ TEST_CASE("Pause() during ST_RUNNING freezes brightness", "[jled]") {
     jled.Update(2);
     const auto brightness_at_pause = jled.GetHal().Value();  // 255
 
-    jled.Pause(2);
+    TimeMock::set_millis(2);
+    jled.Pause();
     CHECK(jled.IsPaused());
 
     // Further updates must not change brightness and must return true
@@ -811,8 +812,10 @@ TEST_CASE("Resume() continues effect from freeze point", "[jled]") {
 
     // Pause at t=2 (elapsed_so_far=2), resume at t=50
     // After resume: effective epoch = 50-2 = 48
-    jled.Pause(2);
-    jled.Resume(50);
+    TimeMock::set_millis(2);
+    jled.Pause();
+    TimeMock::set_millis(50);
+    jled.Resume();
     CHECK_FALSE(jled.IsPaused());
 
     // At t=51: elapsed = 51-48 = 3 → t_cycle=3, on-phase → 255
@@ -829,7 +832,8 @@ TEST_CASE("Pause() in ST_STOPPED is a no-op", "[jled]") {
     jled.Blink(2, 2);
     jled.Update(0, nullptr);
     jled.Stop();
-    jled.Pause(5);
+    TimeMock::set_millis(5);
+    jled.Pause();
     CHECK_FALSE(jled.IsPaused());
     CHECK_FALSE(jled.Update(6));
 }
@@ -838,7 +842,8 @@ TEST_CASE("Pause() in ST_INIT delays effect start until Resume()", "[jled]") {
     TestJLed jled(HalMock(1));
     jled.Blink(2, 2);  // on=[0,1], off=[2,3], period=4
 
-    jled.Pause(0);
+    TimeMock::set_millis(0);
+    jled.Pause();
     CHECK(jled.IsPaused());
 
     // Updates must not start the effect
@@ -848,7 +853,8 @@ TEST_CASE("Pause() in ST_INIT delays effect start until Resume()", "[jled]") {
     CHECK(jled.GetHal().Value() == 0);
 
     // After Resume the effect starts normally on next Update
-    jled.Resume(10);
+    TimeMock::set_millis(10);
+    jled.Resume();
     CHECK_FALSE(jled.IsPaused());
     CHECK(jled.Update(10));
     CHECK(jled.GetHal().Value() == 255);  // t_cycle=0, on-phase
@@ -859,9 +865,12 @@ TEST_CASE("Pause() is idempotent", "[jled]") {
     jled.Blink(4, 4);
     jled.Update(0, nullptr);  // time_start_=0
 
-    jled.Pause(1);   // time_start_ = 1-0 = 1 (elapsed=1 encoded)
-    jled.Pause(99);  // second call — must be no-op, not re-encode
-    jled.Resume(50);  // time_start_ = 50-1 = 49 (epoch restored)
+    TimeMock::set_millis(1);
+    jled.Pause();    // time_start_ = 1-0 = 1 (elapsed=1 encoded)
+    TimeMock::set_millis(99);
+    jled.Pause();    // second call — must be no-op, not re-encode
+    TimeMock::set_millis(50);
+    jled.Resume();   // time_start_ = 50-1 = 49 (epoch restored)
 
     // At t=51: elapsed = 51-49 = 2 → on-phase → 255
     CHECK(jled.Update(51));
@@ -872,9 +881,12 @@ TEST_CASE("Resume() is idempotent", "[jled]") {
     TestJLed jled(HalMock(1));
     jled.Blink(4, 4);
     jled.Update(0, nullptr);
-    jled.Pause(1);
-    jled.Resume(10);  // time_start_ = 10-1 = 9 (epoch)
-    jled.Resume(99);  // second call — must be no-op
+    TimeMock::set_millis(1);
+    jled.Pause();
+    TimeMock::set_millis(10);
+    jled.Resume();   // time_start_ = 10-1 = 9 (epoch)
+    TimeMock::set_millis(99);
+    jled.Resume();   // second call — must be no-op
     CHECK_FALSE(jled.IsPaused());
 
     // At t=11: elapsed = 11-9 = 2 → on-phase → 255
@@ -887,13 +899,15 @@ TEST_CASE("copy of paused JLed preserves pause state", "[jled]") {
     jled.Blink(4, 4);
     jled.Update(0, nullptr);
     jled.Update(2);
-    jled.Pause(2);  // time_start_ = 2-0 = 2 (elapsed=2 encoded)
+    TimeMock::set_millis(2);
+    jled.Pause();   // time_start_ = 2-0 = 2 (elapsed=2 encoded)
 
     TestJLed copy = jled;
     CHECK(copy.IsPaused());
 
     // Copy resumes correctly: time_start_ = 50-2 = 48 (epoch)
-    copy.Resume(50);
+    TimeMock::set_millis(50);
+    copy.Resume();
     // At t=51: elapsed = 51-48 = 3 → on-phase → 255
     CHECK(copy.Update(51));
     CHECK(copy.GetHal().Value() == 255);
@@ -903,7 +917,8 @@ TEST_CASE("Reset() clears pause state", "[jled]") {
     TestJLed jled(HalMock(1));
     jled.Blink(4, 4);
     jled.Update(0, nullptr);
-    jled.Pause(1);
+    TimeMock::set_millis(1);
+    jled.Pause();
     CHECK(jled.IsPaused());
 
     jled.Reset();

--- a/test/test_jled_group.cpp
+++ b/test/test_jled_group.cpp
@@ -422,3 +422,34 @@ TEST_CASE("Pause() freezes sequential group on current LED", "[jled_group]") {
     REQUIRE(!group.Update());  // LED2 finishes, group done
     REQUIRE(HalMock::PinValue(2) == 25);
 }
+
+TEST_CASE("Pause()/Resume() propagate through TJLedRef", "[jled_group]") {
+    HalMock::Init();
+    auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
+    auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 50});
+    TestJLed led1 = TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1);
+    TestJLed led2 = TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1);
+    TJLedRef refs[] = {&led1, &led2};
+    auto group = TestJLedRefGroup::Parallel(refs);
+
+    TimeMock::set_millis(0);
+    REQUIRE(group.Update());  // elapsed=0: 200, 150
+    REQUIRE(HalMock::PinValue(1) == 200);
+    REQUIRE(HalMock::PinValue(2) == 150);
+
+    // Pause freezes both referenced LEDs (FULL_OFF default)
+    TimeMock::set_millis(0);
+    group.Pause();
+    TimeMock::set_millis(1);
+    REQUIRE(group.Update());
+    REQUIRE(HalMock::PinValue(1) == 0);
+    REQUIRE(HalMock::PinValue(2) == 0);
+
+    // Resume continues from the freeze point: at t=51 elapsed=1 -> final tick
+    TimeMock::set_millis(50);
+    group.Resume();
+    TimeMock::set_millis(51);
+    REQUIRE(!group.Update());  // group done
+    REQUIRE(HalMock::PinValue(1) == 100);
+    REQUIRE(HalMock::PinValue(2) == 50);
+}

--- a/test/test_jled_group.cpp
+++ b/test/test_jled_group.cpp
@@ -350,13 +350,13 @@ TEST_CASE("Pause() propagates to all children in parallel group", "[jled_group]"
     // Updates while paused must return true and not change brightness
     TimeMock::set_millis(1);
     REQUIRE(group.Update());
-    REQUIRE(HalMock::PinValue(1) == 200);
-    REQUIRE(HalMock::PinValue(2) == 150);
+    REQUIRE(HalMock::PinValue(1) == 0);
+    REQUIRE(HalMock::PinValue(2) == 0);
 
     TimeMock::set_millis(2);
     REQUIRE(group.Update());
-    REQUIRE(HalMock::PinValue(1) == 200);
-    REQUIRE(HalMock::PinValue(2) == 150);
+    REQUIRE(HalMock::PinValue(1) == 0);
+    REQUIRE(HalMock::PinValue(2) == 0);
 }
 
 TEST_CASE("Resume() continues parallel group from freeze point", "[jled_group]") {
@@ -397,15 +397,15 @@ TEST_CASE("Pause() freezes sequential group on current LED", "[jled_group]") {
     TimeMock::set_millis(1);
     group.Pause();
 
-    // Updates while paused: group returns true, LED1 stays at 200, LED2 not started
+    // Updates while paused: group returns true, LED1 is off (FULL_OFF default), LED2 not started
     TimeMock::set_millis(1);
     REQUIRE(group.Update());
-    REQUIRE(HalMock::PinValue(1) == 200);
+    REQUIRE(HalMock::PinValue(1) == 0);
     REQUIRE(HalMock::PinValue(2) == 0);
 
     TimeMock::set_millis(5);
     REQUIRE(group.Update());
-    REQUIRE(HalMock::PinValue(1) == 200);
+    REQUIRE(HalMock::PinValue(1) == 0);
 
     // Resume: LED1 continues from t_cycle=0 -- next tick it finishes (t_cycle=1 -> 100)
     TimeMock::set_millis(10);

--- a/test/test_jled_group.cpp
+++ b/test/test_jled_group.cpp
@@ -332,3 +332,88 @@ TEST_CASE("JLedRefGroup references externally managed LEDs", "[jled_group]") {
         REQUIRE(!group.Update());
     }
 }
+
+TEST_CASE("Pause() propagates to all children in parallel group", "[jled_group]") {
+    HalMock::Init();
+    auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100, 50});
+    auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 75, 25});
+    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    auto group = TestJLedGroupAny::Parallel(leds, 2);
+
+    TimeMock::set_millis(0);
+    REQUIRE(group.Update());  // t=0: brightness 200, 150
+
+    group.Pause(1);
+
+    // Updates while paused must return true and not change brightness
+    TimeMock::set_millis(1);
+    REQUIRE(group.Update());
+    REQUIRE(HalMock::PinValue(1) == 200);
+    REQUIRE(HalMock::PinValue(2) == 150);
+
+    TimeMock::set_millis(2);
+    REQUIRE(group.Update());
+    REQUIRE(HalMock::PinValue(1) == 200);
+    REQUIRE(HalMock::PinValue(2) == 150);
+}
+
+TEST_CASE("Resume() continues parallel group from freeze point", "[jled_group]") {
+    HalMock::Init();
+    auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
+    auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 50});
+    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    auto group = TestJLedGroupAny::Parallel(leds, 2);
+
+    // Advance to t=0 (elapsed=0, first values output)
+    TimeMock::set_millis(0);
+    REQUIRE(group.Update());
+
+    // Pause at t=0, resume at t=50 — children should see elapsed=1 at t=51
+    group.Pause(0);
+    group.Resume(50);
+
+    TimeMock::set_millis(51);
+    REQUIRE(!group.Update());  // elapsed=1, final tick, group done
+    REQUIRE(HalMock::PinValue(1) == 100);
+    REQUIRE(HalMock::PinValue(2) == 50);
+}
+
+TEST_CASE("Pause() freezes sequential group on current LED", "[jled_group]") {
+    HalMock::Init();
+    auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
+    auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
+    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    auto group = TestJLedGroupAny::Sequential(leds);
+
+    TimeMock::set_millis(0);
+    REQUIRE(group.Update());  // LED1 at t_cycle=0 -> 200
+
+    group.Pause(1);
+
+    // Updates while paused: group returns true, LED1 stays at 200, LED2 not started
+    TimeMock::set_millis(1);
+    REQUIRE(group.Update());
+    REQUIRE(HalMock::PinValue(1) == 200);
+    REQUIRE(HalMock::PinValue(2) == 0);
+
+    TimeMock::set_millis(5);
+    REQUIRE(group.Update());
+    REQUIRE(HalMock::PinValue(1) == 200);
+
+    // Resume: LED1 continues from t_cycle=0 -- next tick it finishes (t_cycle=1 -> 100)
+    group.Resume(10);
+    TimeMock::set_millis(11);
+    REQUIRE(group.Update());   // LED1 finishes, LED2 starts
+    REQUIRE(HalMock::PinValue(1) == 100);
+
+    TimeMock::set_millis(12);
+    REQUIRE(group.Update());   // LED2 running
+    REQUIRE(HalMock::PinValue(2) == 50);
+
+    TimeMock::set_millis(13);
+    REQUIRE(!group.Update());  // LED2 finishes, group done
+    REQUIRE(HalMock::PinValue(2) == 25);
+}

--- a/test/test_jled_group.cpp
+++ b/test/test_jled_group.cpp
@@ -250,18 +250,18 @@ TEST_CASE("JLedAny copy constructor copies all state", "[jled_group]") {
 
     SECTION("copy of JLed") {
         TestJLedAny src(TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1));
-        TestJLedAny dst(src);
+        TestJLedAny arr[] = {src};
         TimeMock::set_millis(0);
-        dst.Update(0);
+        TestJLedGroupAny::Parallel(arr).Update(0);
         REQUIRE(HalMock::PinValue(1) == 255);
     }
 
     SECTION("copy of JLedGroup") {
         TestJLedAny led_arr[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1)};
         TestJLedAny src(TestJLedGroupAny::Parallel(led_arr));
-        TestJLedAny dst(src);
+        TestJLedAny arr[] = {src};
         TimeMock::set_millis(0);
-        dst.Update(0);
+        TestJLedGroupAny::Parallel(arr).Update(0);
         REQUIRE(HalMock::PinValue(1) == 255);
     }
 }
@@ -344,7 +344,8 @@ TEST_CASE("Pause() propagates to all children in parallel group", "[jled_group]"
     TimeMock::set_millis(0);
     REQUIRE(group.Update());  // t=0: brightness 200, 150
 
-    group.Pause(1);
+    TimeMock::set_millis(1);
+    group.Pause();
 
     // Updates while paused must return true and not change brightness
     TimeMock::set_millis(1);
@@ -371,8 +372,10 @@ TEST_CASE("Resume() continues parallel group from freeze point", "[jled_group]")
     REQUIRE(group.Update());
 
     // Pause at t=0, resume at t=50 — children should see elapsed=1 at t=51
-    group.Pause(0);
-    group.Resume(50);
+    TimeMock::set_millis(0);
+    group.Pause();
+    TimeMock::set_millis(50);
+    group.Resume();
 
     TimeMock::set_millis(51);
     REQUIRE(!group.Update());  // elapsed=1, final tick, group done
@@ -391,7 +394,8 @@ TEST_CASE("Pause() freezes sequential group on current LED", "[jled_group]") {
     TimeMock::set_millis(0);
     REQUIRE(group.Update());  // LED1 at t_cycle=0 -> 200
 
-    group.Pause(1);
+    TimeMock::set_millis(1);
+    group.Pause();
 
     // Updates while paused: group returns true, LED1 stays at 200, LED2 not started
     TimeMock::set_millis(1);
@@ -404,7 +408,8 @@ TEST_CASE("Pause() freezes sequential group on current LED", "[jled_group]") {
     REQUIRE(HalMock::PinValue(1) == 200);
 
     // Resume: LED1 continues from t_cycle=0 -- next tick it finishes (t_cycle=1 -> 100)
-    group.Resume(10);
+    TimeMock::set_millis(10);
+    group.Resume();
     TimeMock::set_millis(11);
     REQUIRE(group.Update());   // LED1 finishes, LED2 starts
     REQUIRE(HalMock::PinValue(1) == 100);


### PR DESCRIPTION
The new Pause and Resume feature allows to pause and later resume a single effect or a group of effects. The implementation does not increasethe memory footprint of JLed objects, no state needs to be stored. Example use:

```c++
#include <ezButton.h>  // arduinogetstarted/ezButton@1.0.6
#include <jled.h>

constexpr auto LED_PIN = 16;
constexpr auto BUTTON_PIN = 18;

auto button = ezButton(BUTTON_PIN);
auto led = JLed(LED_PIN).Breathe(2000).Forever();

void setup() {}

void loop() {
    button.loop();

    if (button.isPressed()) {
        if (led.IsPaused()) {
            led.Resume();
        } else {
            led.Pause();
        }
    }

    led.Update();
}
```

Behaviour of `Pause()` is controllable by an optional idle mode parameter, similar to the `Stop()` method (keep current, off, min-brightness)