### PR TITLE
Harmonize idlemode in stop and pause across jled and jledgroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,8 +619,9 @@ automatically. A runtime-size overload is also available:
   running, `false` when it has finished.
 - `Repeat(n)` - plays the group `n` times. Default is 1.
 - `Forever()` - plays the group indefinitely.
-- `Stop()` - stops all elements immediately. Further calls to `Update()`
-  have no effect.
+- `Stop(mode = jled::eIdleMode::TO_MIN_BRIGHTNESS)` - stops all elements
+  immediately. `mode` controls the final brightness of each LED, identical to
+  [`JLed::Stop(mode)`](#immediate-stop). Further calls to `Update()` have no effect.
 - `Reset()` - resets all elements and restarts the group from the beginning.
 
 `JLedAny` has a fixed-size internal buffer sized to hold `JLed`, `JLedHD`,

--- a/README.md
+++ b/README.md
@@ -526,10 +526,15 @@ led.Stop(JLed::eStopMode::FULL_OFF);
 
 ### Pause and Resume
 
-Call `Pause()` to freeze the current effect at its current brightness. While paused,
-`Update()` returns `true` but does not advance the effect or change the brightness output.
-Call `Resume()` to continue the effect from the exact point where it was paused. `IsPaused()`
-returns `true` while the effect is frozen.
+Call `Pause()` to freeze the current effect. While paused, `Update()` returns `true` but
+does not advance the effect. Call `Resume()` to continue from the exact point where it was
+paused. `IsPaused()` returns `true` while the effect is frozen.
+
+`Pause()` accepts an optional `mode` argument of type `jled::eIdleMode` (same values as
+`Stop()`) that controls the LED's brightness during the pause. The default is
+`jled::eIdleMode::TO_MIN_BRIGHTNESS`, which sets the LED to its configured minimum
+brightness. Use `jled::eIdleMode::KEEP_CURRENT` to hold the last rendered value, or
+`jled::eIdleMode::FULL_OFF` to force the LED off regardless of `MinBrightness`.
 
 Pausing before an effect has started is valid: the effect will not start until
 `Resume()` is called.

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -442,7 +442,7 @@ class TJLed : public JLedBase {
 
     bool IsRunning() const { return state_ != ST_STOPPED; }
 
-    void Pause(eIdleMode mode = eIdleMode::FULL_OFF) { Pause(Clock::millis(), mode); }
+    void Pause(eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS) { Pause(Clock::millis(), mode); }
     void Resume() { Resume(Clock::millis()); }
 
     bool IsPaused() const { return bPaused_; }
@@ -550,7 +550,7 @@ class TJLed : public JLedBase {
     }
 
  protected:
-    void Pause(uint32_t t, eIdleMode mode = eIdleMode::FULL_OFF) {
+    void Pause(uint32_t t, eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS) {
         if (bPaused_ || state_ == ST_STOPPED) return;
         bPaused_ = true;
         if (mode != eIdleMode::KEEP_CURRENT) {
@@ -698,7 +698,7 @@ class TJLedGroup {
     bool Update(uint32_t t);
     void Reset();
     void Stop(eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS);
-    void Pause(eIdleMode mode = eIdleMode::FULL_OFF);
+    void Pause(eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS);
     void Resume();
 
     TJLedGroup(eMode mode, AnyType* leds, size_t n)
@@ -706,7 +706,7 @@ class TJLedGroup {
     }
 
  protected:
-    void Pause(uint32_t t, eIdleMode mode = eIdleMode::FULL_OFF);
+    void Pause(uint32_t t, eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS);
     void Resume(uint32_t t);
 
     template <size_t N> friend struct TJLedAny;
@@ -806,7 +806,7 @@ struct TJLedAny {
     bool Update(uint32_t t) { return vtable_->update(buf_, t); }
     void Reset()            { vtable_->reset(buf_); }
     void Stop(eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS) { vtable_->stop(buf_, mode); }
-    void Pause(uint32_t t, eIdleMode mode = eIdleMode::FULL_OFF) {
+    void Pause(uint32_t t, eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS) {
         vtable_->pause(buf_, t, mode);
     }
     void Resume(uint32_t t) { vtable_->resume(buf_, t); }
@@ -857,7 +857,7 @@ class TJLedRef {
     bool Update(uint32_t t) { return vtable_->update(obj_, t); }
     void Reset()            { vtable_->reset(obj_); }
     void Stop(eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS) { vtable_->stop(obj_, mode); }
-    void Pause(uint32_t t, eIdleMode mode = eIdleMode::FULL_OFF) {
+    void Pause(uint32_t t, eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS) {
         vtable_->pause(obj_, t, mode);
     }
     void Resume(uint32_t t) { vtable_->resume(obj_, t); }

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -697,7 +697,7 @@ class TJLedGroup {
     bool Update();
     bool Update(uint32_t t);
     void Reset();
-    void Stop();
+    void Stop(eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS);
     void Pause(eIdleMode mode = eIdleMode::FULL_OFF);
     void Resume();
 
@@ -741,7 +741,7 @@ struct TJLedAny {
     struct Vtable {
         bool (*update)(void*, uint32_t);
         void (*reset)(void*);
-        void (*stop)(void*);
+        void (*stop)(void*, eIdleMode);
         void (*pause)(void*, uint32_t, eIdleMode);
         void (*resume)(void*, uint32_t);
         void (*copy)(void* dst, const void* src);
@@ -756,7 +756,7 @@ struct TJLedAny {
         static const Vtable kVt = {
             [](void* p, uint32_t t) -> bool { return static_cast<T*>(p)->Update(t); },
             [](void* p) { static_cast<T*>(p)->Reset(); },
-            [](void* p) { static_cast<T*>(p)->Stop(); },
+            [](void* p, eIdleMode m) { static_cast<T*>(p)->Stop(m); },
             [](void* p, uint32_t t, eIdleMode m) { static_cast<T*>(p)->Pause(t, m); },
             [](void* p, uint32_t t) { static_cast<T*>(p)->Resume(t); },
             [](void* dst, const void* src) {
@@ -805,7 +805,7 @@ struct TJLedAny {
  protected:
     bool Update(uint32_t t) { return vtable_->update(buf_, t); }
     void Reset()            { vtable_->reset(buf_); }
-    void Stop()             { vtable_->stop(buf_); }
+    void Stop(eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS) { vtable_->stop(buf_, mode); }
     void Pause(uint32_t t, eIdleMode mode = eIdleMode::FULL_OFF) {
         vtable_->pause(buf_, t, mode);
     }
@@ -822,7 +822,7 @@ class TJLedRef {
     struct Vtable {
         bool (*update)(void*, uint32_t);
         void (*reset)(void*);
-        void (*stop)(void*);
+        void (*stop)(void*, eIdleMode);
         void (*pause)(void*, uint32_t, eIdleMode);
         void (*resume)(void*, uint32_t);
     };
@@ -834,7 +834,7 @@ class TJLedRef {
         static const Vtable kVt = {
             [](void* p, uint32_t t) -> bool { return static_cast<T*>(p)->Update(t); },
             [](void* p) { static_cast<T*>(p)->Reset(); },
-            [](void* p) { static_cast<T*>(p)->Stop(); },
+            [](void* p, eIdleMode m) { static_cast<T*>(p)->Stop(m); },
             [](void* p, uint32_t t, eIdleMode m) { static_cast<T*>(p)->Pause(t, m); },
             [](void* p, uint32_t t) { static_cast<T*>(p)->Resume(t); }
         };
@@ -856,7 +856,7 @@ class TJLedRef {
  protected:
     bool Update(uint32_t t) { return vtable_->update(obj_, t); }
     void Reset()            { vtable_->reset(obj_); }
-    void Stop()             { vtable_->stop(obj_); }
+    void Stop(eIdleMode mode = eIdleMode::TO_MIN_BRIGHTNESS) { vtable_->stop(obj_, mode); }
     void Pause(uint32_t t, eIdleMode mode = eIdleMode::FULL_OFF) {
         vtable_->pause(obj_, t, mode);
     }
@@ -928,10 +928,10 @@ void TJLedGroup<Clock, AnyType>::Reset() {
 }
 
 template <typename Clock, typename AnyType>
-void TJLedGroup<Clock, AnyType>::Stop() {
+void TJLedGroup<Clock, AnyType>::Stop(eIdleMode mode) {
     is_running_ = false;
     for (auto i = 0u; i < n_; i++) {
-        leds_[i].Stop();
+        leds_[i].Stop(mode);
     }
 }
 

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -556,6 +556,19 @@ TEST_CASE("Pause(TO_MIN_BRIGHTNESS) sets brightness to minimum", "[jled]") {
     CHECK(50 == static_cast<int>(jled.GetHal().Value()));
 }
 
+TEST_CASE("Pause() default mode is TO_MIN_BRIGHTNESS", "[jled]") {
+    auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{100, 0});
+    TestJLed jled = TestJLed(10).UserFunc(&eval).MinBrightness(50);
+
+    jled.Update();
+    REQUIRE(130 ==
+            static_cast<int>(jled.GetHal().Value()));  // 100 scaled to [50,255]
+
+    TimeMock::set_millis(1);
+    jled.Pause();
+    CHECK(50 == static_cast<int>(jled.GetHal().Value()));
+}
+
 TEST_CASE("LowActive() inverts signal", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{0, 255});
     TestJLed jled = TestJLed(1).UserFunc(&eval).LowActive();
@@ -821,7 +834,7 @@ TEST_CASE("lerp8by8 interpolates a byte into the given interval",
     CHECK(200 == (int)(jled::lerp8by8(255, 100, 200)));
 }
 
-TEST_CASE("Pause() during ST_RUNNING turns LED off (FULL_OFF default)", "[jled]") {
+TEST_CASE("Pause() during ST_RUNNING sets LED to minBrightness", "[jled]") {
     TestJLed jled(HalMock(1));
     jled.Blink(4, 4);  // on for t_cycle=0..3, off for t_cycle=4..7, done at t=8
 

--- a/test/test_jled_group.cpp
+++ b/test/test_jled_group.cpp
@@ -376,6 +376,21 @@ TEST_CASE("JLedRefGroup references externally managed LEDs", "[jled_group]") {
     }
 }
 
+TEST_CASE("Pause() default mode is TO_MIN_BRIGHTNESS", "[jled_group]") {
+    HalMock::Init();
+    auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
+    TestJLedAny leds[] = {
+        TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
+    auto group = TestJLedGroupAny::Parallel(leds);
+
+    TimeMock::set_millis(0);
+    REQUIRE(group.Update());
+
+    TimeMock::set_millis(1);
+    group.Pause();
+    REQUIRE(HalMock::PinValue(1) == 50);
+}
+
 TEST_CASE("Pause() propagates to all children in parallel group", "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100, 50});

--- a/test/test_jled_group.cpp
+++ b/test/test_jled_group.cpp
@@ -208,6 +208,49 @@ TEST_CASE("nested JLedGroup within JLedGroup", "[jled_group]") {
     REQUIRE(HalMock::PinValue(2) == 25);
 }
 
+TEST_CASE("Stop(FULL_OFF) sets group LEDs to 0 regardless of MinBrightness",
+          "[jled_group]") {
+    HalMock::Init();
+    auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
+    TestJLedAny leds[] = {
+        TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
+    auto group = TestJLedGroupAny::Parallel(leds);
+
+    TimeMock::set_millis(0);
+    REQUIRE(group.Update());
+
+    group.Stop(jled::eIdleMode::FULL_OFF);
+    REQUIRE(HalMock::PinValue(1) == 0);
+}
+
+TEST_CASE("Stop(TO_MIN_BRIGHTNESS) sets group LEDs to minBrightness", "[jled_group]") {
+    HalMock::Init();
+    auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
+    TestJLedAny leds[] = {
+        TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
+    auto group = TestJLedGroupAny::Parallel(leds);
+
+    TimeMock::set_millis(0);
+    REQUIRE(group.Update());
+
+    group.Stop(jled::eIdleMode::TO_MIN_BRIGHTNESS);
+    REQUIRE(HalMock::PinValue(1) == 50);
+}
+
+TEST_CASE("Stop(KEEP_CURRENT) leaves group LEDs at current brightness", "[jled_group]") {
+    HalMock::Init();
+    auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
+    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1)};
+    auto group = TestJLedGroupAny::Parallel(leds);
+
+    TimeMock::set_millis(0);
+    REQUIRE(group.Update());
+    REQUIRE(HalMock::PinValue(1) == 200);
+
+    group.Stop(jled::eIdleMode::KEEP_CURRENT);
+    REQUIRE(HalMock::PinValue(1) == 200);
+}
+
 TEST_CASE("Stop propagates to nested group and inner LEDs", "[jled_group]") {
     HalMock::Init();
     auto outer_eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});


### PR DESCRIPTION
* `TJLedGroup::Stop()` also support `jled::eIdleMode` like in `TJLed`
* `mode` in `Stop()` and `Pause()` both default  to `TO_MIN_BRIGHTNESS`  to avoid surprises