### PR TITLE
new: long running breathe example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,7 @@ Example sketches are provided in the [examples](examples/) directory.
 - [High resolution effects with JLedHD](examples/hires)
 - [Turn LED on after a delay](examples/simple_on)
 - [Breathe effect](examples/breathe)
+- [Long running breathe effect](examples/slow_breathe)
 - [Candle effect](examples/candle)
 - [Fade LED on](examples/fade_on)
 - [Fade LED off](examples/fade_off)

--- a/examples/slow_breathe/slow_breathe.ino
+++ b/examples/slow_breathe/slow_breathe.ino
@@ -1,0 +1,19 @@
+// Extra long running breathe example.
+// Copyright 2026 by Jan Delgado. All rights reserved.
+// https://github.com/jandelgado/jled
+//
+// Normally an effect's period is limited to ca. 65s. However by scaling and explicitly
+// passing the time to Update(), we can make the clock appear to run "slower" and
+// have effects run longer.
+#include <jled.h>
+
+// make sure to use a MCU and GPIO that supports high resolution PWM. Otherwise
+// brightness steps will become visible.
+auto led = JLedHD(16).Breathe(65000).Forever();
+
+void setup() {}
+
+void loop() {
+    // dividing the time by two effectively doubles the period
+    led.Update(jled::JLedClockType::millis()/2);
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -42,6 +42,7 @@ src_dir = examples/hello
 ;src_dir = examples/pause_resume
 ;src_dir = examples/pulse
 ;src_dir = examples/simple_on
+;src_dir = examples/slow_breathe
 ;src_dir = examples/user_func
 
 [env]


### PR DESCRIPTION
The period of effects is limited to 65535ms. This examples shows how to run effects longer, by explicitly passing a scaled time to the Update()  method of JLed.