### PR TITLE
Move signal inversion to HAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased - scheduled for JLed 5.0]
 
+- new: `LowActive(bool on = true)` accepts a parameter, so low-active
+  polarity can be toggled off again with `LowActive(false)` without
+  needing a separate API. Existing `LowActive()` calls are unaffected
 - new: lifecycle events (`kStart`/`kActive`/`kRepeatStart`/`kEnterDelayAfter`/`kDone`)
   for `TJLed` via `UpdateResult`, with `IsStarted()`/`IsActive()`/... queries
   and matching `OnStart()`/`OnActive()`/... callbacks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@
 - new: high resolution (up to 16-bit effect) with `JLedHD`
 - new/breaking: `JLedGroup`/`JLedRefGroup` as a flexible `JLedSequence` replacement
 - new: `Blink` effect now has a repeat parameter
+- breaking (HAL authors only): the HAL concept's `analogWrite()` gains a required second
+  parameter, `analogWrite<Color>(Color val, bool invert)`. `LowActive()`/`IsLowActive()`
+  and all other public JLed/JLedHD/JLedGroup/JLedAny API is unaffected. A custom HAL
+  written before this change needs to either add the parameter directly, or wrap the HAL
+  in the new `InvertableHal<Hal>` decorator (`src/invertable_hal.h`), which adapts an
+  unmodified single-argument `analogWrite(Color)` to the new signature at zero storage
+  cost. All bundled HALs (Arduino, ESP32, ESP8266, mbed, Pico) use `InvertableHal`'s
+  software fallback
 
 ## [2024-12-01] 4.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@
   unmodified single-argument `analogWrite(Color)` to the new signature at zero storage
   cost. All bundled HALs (Arduino, ESP32, ESP8266, mbed, Pico) use `InvertableHal`'s
   software fallback
+- breaking (HAL authors only): the HAL concept gains a required `SetLowActive(bool)`
+  method, called once from `LowActive()`. HALs with a hardware polarity register use it
+  to pre-arm the register; HALs without one (all `InvertableHal`-wrapped HALs) implement
+  it as a no-op, since `analogWrite(val, invert)` already applies inversion on every
+  call. A custom HAL written before this change needs to add the method, or wrap the HAL
+  in `InvertableHal<Hal>` to get the no-op for free. `Esp32Hal` and `PicoHal` now use this
+  to invert natively (a GPIO-matrix bit via `gpio_matrix_out()`, and a masked PWM CSR
+  write via `hw_write_masked()`, respectively) instead of `InvertableHal`'s software
+  fallback
 
 ## [2024-12-01] 4.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,17 +30,19 @@
   written before this change needs to either add the parameter directly, or wrap the HAL
   in the new `InvertableHal<Hal>` decorator (`src/invertable_hal.h`), which adapts an
   unmodified single-argument `analogWrite(Color)` to the new signature at zero storage
-  cost. All bundled HALs (Arduino, ESP32, ESP8266, mbed, Pico) use `InvertableHal`'s
-  software fallback
+  cost. Of the bundled HALs, Arduino, ESP8266 and mbed use `InvertableHal`'s software
+  fallback; ESP32 and Pico invert natively instead, see below
 - breaking (HAL authors only): the HAL concept gains a required `SetLowActive(bool)`
   method, called once from `LowActive()`. HALs with a hardware polarity register use it
   to pre-arm the register; HALs without one (all `InvertableHal`-wrapped HALs) implement
   it as a no-op, since `analogWrite(val, invert)` already applies inversion on every
   call. A custom HAL written before this change needs to add the method, or wrap the HAL
   in `InvertableHal<Hal>` to get the no-op for free. `Esp32Hal` and `PicoHal` now use this
-  to invert natively (a GPIO-matrix bit via `gpio_matrix_out()`, and a masked PWM CSR
-  write via `hw_write_masked()`, respectively) instead of `InvertableHal`'s software
-  fallback
+  to invert natively (the LEDC driver's own `output_invert` flag on ESP32, and a masked
+  PWM CSR write via `hw_write_masked()` on Pico) instead of `InvertableHal`'s software
+  fallback. `output_invert` requires ESP-IDF >= 4.4; on older SDKs `Esp32Hal` doesn't
+  define `SetLowActive()`/`analogWrite(val, invert)` at all, and `jled.h` falls back to
+  wrapping it in `InvertableHal` instead, same as Arduino/ESP8266/mbed
 
 ## [2024-12-01] 4.15.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Catch2 (amalgamated in `test/catch2/`). `TEST_CASE("what", "[tag]")`, `SECTION()
 ## Common Tasks
 
 - **New effect**: evaluator in `src/jled_effects.h`, fluent method in `src/jled_base.h` (ref `BlinkBrightnessEvaluator` / `TJLed::Blink`). Add tests, an example, a `README.md` entry.
-- **New HAL**: copy `src/arduino_hal.h`, add detection in `src/jled.h`, add `test/test_[platform]_hal.cpp`. The HAL concept's `analogWrite()` requires two arguments, `analogWrite<Color>(Color val, bool invert)`; if your HAL has no native inversion capability, implement a plain single-argument `analogWrite(Color val)` and wrap it in `InvertableHal<YourHal>` (`src/invertable_hal.h`) to get software inversion for free.
+- **New HAL**: copy `src/arduino_hal.h`, add detection in `src/jled.h`, add `test/test_[platform]_hal.cpp`. The HAL concept's `analogWrite()` requires two arguments, `analogWrite<Color>(Color val, bool invert)`; if your HAL has no native inversion capability, implement a plain single-argument `analogWrite(Color val)` and wrap it in `InvertableHal<YourHal>` (`src/invertable_hal.h`) to get software inversion for free. The HAL concept also requires `void SetLowActive(bool)`, called once from `LowActive()`; a HAL with a hardware polarity register uses it to pre-arm that register, while `InvertableHal` implements it as a no-op for HALs without one. See `Esp32Hal`/`PicoHal` for examples of the former.
 - **Bug fix**: failing test first, then fix, then `make test`, `make coverage`, `make lint`.
 
 Every change adds tests. Run `make lint && make test` before commit. Don't change a test to make it pass; fix the code. Correctness over completeness: don't guess or invent APIs/files/configs; label assumptions; ask when unsure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Catch2 (amalgamated in `test/catch2/`). `TEST_CASE("what", "[tag]")`, `SECTION()
 ## Common Tasks
 
 - **New effect**: evaluator in `src/jled_effects.h`, fluent method in `src/jled_base.h` (ref `BlinkBrightnessEvaluator` / `TJLed::Blink`). Add tests, an example, a `README.md` entry.
-- **New HAL**: copy `src/arduino_hal.h`, add detection in `src/jled.h`, add `test/test_[platform]_hal.cpp`.
+- **New HAL**: copy `src/arduino_hal.h`, add detection in `src/jled.h`, add `test/test_[platform]_hal.cpp`. The HAL concept's `analogWrite()` requires two arguments, `analogWrite<Color>(Color val, bool invert)`; if your HAL has no native inversion capability, implement a plain single-argument `analogWrite(Color val)` and wrap it in `InvertableHal<YourHal>` (`src/invertable_hal.h`) to get software inversion for free.
 - **Bug fix**: failing test first, then fix, then `make test`, `make coverage`, `make lint`.
 
 Every change adds tests. Run `make lint && make test` before commit. Don't change a test to make it pass; fix the code. Correctness over completeness: don't guess or invent APIs/files/configs; label assumptions; ask when unsure.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,14 @@
 if(IDF_VER) # ESP-IDF component (ESP32)
 
     idf_component_register(
-        SRCS "src/jled_base.cpp" "src/esp32_hal.cpp"  
-        INCLUDE_DIRS "src")
+        SRCS "src/jled_effects.cpp"
+        INCLUDE_DIRS "src"
+        REQUIRES esp_driver_ledc esp_timer)
 
     idf_build_set_property(COMPILE_OPTIONS "-DESP32" APPEND)
     set_target_properties(${TARGET} PROPERTIES LINKER_LANGUAGE CXX)
 
 else() # Raspberry Pi Pico
-	add_library (JLed src/jled_base.cpp)
+	add_library (JLed src/jled_effects.cpp)
 	target_include_directories (JLed PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 endif()

--- a/README.md
+++ b/README.md
@@ -633,17 +633,14 @@ the entire group freezes and resumes in sync.
 
 #### Low active for inverted output
 
-Use the `LowActive()` method when the connected LED is low active. All output
-will be inverted (i.e., instead of x, the value of `FullBrightness - x` will be
-set, where `FullBrightness` is 255 for `JLed` and 65535 for `JLedHD`).
+Use the `LowActive()` method when the connected LED is low active (common anode). All output
+will be inverted then. Call `LowActive(false)` to switch back to normal (high active) output.
 Use `IsLowActive()` to query whether the LED is configured as low active.
 
 Inversion is performed by the HAL layer: on Raspberry Pi Pico, and on ESP32 with ESP-IDF
 ≥ 4.4, it is done in hardware (a PWM-CSR polarity bit / the LEDC driver's `output_invert`
-flag, armed once when `LowActive()` is called), with `InvertableHal`'s software fallback
-used on ESP-IDF < 4.4 and every other bundled platform. This is transparent to `JLed`/`JLedHD` users;
-it only matters if you are writing a custom HAL, see the "New HAL" section in
-`CLAUDE.md`.
+flag is set when `LowActive()` is called). `InvertableHal` is a software fallback
+used on ESP-IDF < 4.4 and every other bundled platform.
 
 #### Minimum- and Maximum brightness level
 

--- a/README.md
+++ b/README.md
@@ -634,9 +634,14 @@ the entire group freezes and resumes in sync.
 #### Low active for inverted output
 
 Use the `LowActive()` method when the connected LED is low active. All output
-will be inverted by JLed (i.e., instead of x, the value of `FullBrightness - x`
-will be set, where `FullBrightness` is 255 for `JLed` and 65535 for `JLedHD`).
+will be inverted (i.e., instead of x, the value of `FullBrightness - x` will be
+set, where `FullBrightness` is 255 for `JLed` and 65535 for `JLedHD`).
 Use `IsLowActive()` to query whether the LED is configured as low active.
+
+Inversion is performed by the HAL layer, via `InvertableHal`'s software
+fallback on all bundled platforms. This is transparent to `JLed`/`JLedHD`
+users; it only matters if you are writing a custom HAL, see the "New HAL"
+section in `CLAUDE.md`.
 
 #### Minimum- and Maximum brightness level
 
@@ -1281,12 +1286,15 @@ class CustomJLed : public jled::TJLed<CustomHal, CustomJLed> { ... };
 
 // after
 class CustomHal {
-    void analogWrite(uint8_t val) const;  // millis() gone
+    void analogWrite(uint8_t val, bool invert) const;  // millis() gone; invert added for low-active support
 };
 class CustomJLed : public jled::TJLed<CustomHal, jled::JLedClockType, uint8_t, CustomJLed> { ... };
 ```
 
-See the [custom_hal](examples/custom_hal) example for a complete implementation.
+See the [custom_hal](examples/custom_hal) example for a complete implementation. See the
+[Low active for inverted output](#low-active-for-inverted-output) section for the
+`analogWrite(val, invert)` contract, and `InvertableHal<Hal>` if your HAL has no native inversion
+capability.
 
 Reason: a platform may have multiple PWM HALs (for example the built-in one plus an external PCA9685
 driver) but only a single clock. Separating them avoids duplicating time logic across HALs. Making

--- a/README.md
+++ b/README.md
@@ -638,10 +638,10 @@ will be inverted (i.e., instead of x, the value of `FullBrightness - x` will be
 set, where `FullBrightness` is 255 for `JLed` and 65535 for `JLedHD`).
 Use `IsLowActive()` to query whether the LED is configured as low active.
 
-Inversion is performed by the HAL layer: on ESP32 and Raspberry Pi Pico it is
-done in hardware (a GPIO-matrix / PWM-CSR polarity bit, armed once when
-`LowActive()` is called), with `InvertableHal`'s software fallback used on
-every other bundled platform. This is transparent to `JLed`/`JLedHD` users;
+Inversion is performed by the HAL layer: on Raspberry Pi Pico, and on ESP32 with ESP-IDF
+≥ 4.4, it is done in hardware (a PWM-CSR polarity bit / the LEDC driver's `output_invert`
+flag, armed once when `LowActive()` is called), with `InvertableHal`'s software fallback
+used on ESP-IDF < 4.4 and every other bundled platform. This is transparent to `JLed`/`JLedHD` users;
 it only matters if you are writing a custom HAL, see the "New HAL" section in
 `CLAUDE.md`.
 
@@ -893,7 +893,9 @@ pull the LEDs out into named variables and swap the array type.
 
 ## Framework notes
 
-JLed supports the Arduino and [mbed](https://www.mbed.org) frameworks. When
+JLed supports the Arduino and [mbed](https://www.mbed.org) frameworks, as well as native
+Pico-SDK and ESP-IDF builds without any framework at all (see the [Raspberry Pi
+Pico](#raspberry-pi-pico) and [ESP32](#esp32) sections). When
 using platformio, the framework to be used is configured in the `platform.ini`
 file, as shown in the following example, which for example selects the `mbed`
 framework:
@@ -946,8 +948,8 @@ each supported platform:
 
 | Platform                                                | `JLed`                    | `JLedHD`                  |
 | ------------------------------------------------------- | ------------------------- | ------------------------- |
-| ESP32 (native SDK / ESP-IDF)                            | `Esp32Hal<8>` (8-bit)     | `Esp32Hal<13>` (13-bit)   |
-| Raspberry Pi Pico (native Pico SDK)                     | `PicoHal<8>` (8-bit)      | `PicoHal<16>` (16-bit)    |
+| ESP32 (default)                                         | `Esp32Hal<8>` (8-bit)     | `Esp32Hal<13>` (13-bit)   |
+| Raspberry Pi Pico (default)                             | `PicoHal<8>` (8-bit)      | `PicoHal<16>` (16-bit)    |
 | mbed                                                    | `MbedHal<8>` (8-bit)      | `MbedHal<16>` (16-bit)    |
 | Teensy 4.x / 3.x / LC                                   | `ArduinoHal<8>` (8-bit)   | `ArduinoHal<16>` (16-bit) |
 | SAMD21 (Arduino Zero, MKR series) / Arduino Due         | `ArduinoHal<8>` (8-bit)   | `ArduinoHal<12>` (12-bit) |
@@ -995,7 +997,9 @@ build_flags = -DJLED_FORCE_ARDUINO_HAL
 
 When `JLED_FORCE_ARDUINO_HAL` is set on an RP2040 board, `JLedHD` maps to
 `ArduinoHal<16>` (Earle Philhower arduino-pico SDK) instead of `PicoHal<16>`, subject to
-the global `analogWriteResolution` constraint described above.
+the global `analogWriteResolution` constraint described above. On ESP32, the flag falls
+back to `ArduinoHal<8>` for both `JLed` and `JLedHD`, so they share the same resolution
+and can be mixed freely.
 
 ### ESP8266
 
@@ -1003,8 +1007,8 @@ The ESP8266 PWM peripheral supports up to 10-bit resolution. On Arduino core v1/
 and `JLedHD` operate at native 10-bit resolution (`ArduinoHal<10>`), with brightness values
 scaled from 8-bit or 16-bit internal precision accordingly. ESP8266 Arduino core v3+ reverted
 the `analogWrite()` default to 8 bits for compatibility, so `JLed` maps to `ArduinoHal<8>`
-there. `JLedHD`, however, stays at `ArduinoHal<10>`: the HAL calls `analogWriteResolution(10)`
-(available since core v3) to restore full 10-bit output, so `JLedHD` keeps its extra resolution
+there. `JLedHD`, however, stays at `ArduinoHal<10>` so the HAL calls `analogWriteResolution(10)`
+(available since core v3) to restore full 10-bit output. `JLedHD` keeps its extra resolution
 on every ESP8266 core version. Because `JLed` and `JLedHD` then differ in width, they cannot be
 mixed in the same sketch on core v3+ (see the [`ArduinoHal`
 note](#arduinohal-and-the-global-analogwriteresolution-limit) above); on core v1/v2 both are
@@ -1034,9 +1038,7 @@ brightness gradients at the cost of a lower maximum PWM frequency. At 13-bit res
 and the default 5 kHz base frequency the ESP32 is still well within its hardware limits.
 
 The `jled::Esp32Hal(pin, chan)` constructor takes the pin number as the first
-argument and the ESP32 ledc channel number on the second position. Note that
-using the above-mentioned constructor results in non-platform independent code,
-so it should be avoided and is normally not necessary.
+argument and the ESP32 ledc channel number on the second position.
 
 For completeness, the full signature of the `Esp32Hal` constructor is
 
@@ -1076,11 +1078,11 @@ possible). See these repositories for example projects:
 #### Arduino framework
 
 I had success running JLed on a [STM32 Nucleo64 F401RE
-board](https://www.st.com/en/evaluation-tools/nucleo-f401re.html) using this
-[STM32 Arduino
-core](https://github.com/rogerclarkmelbourne/Arduino_STM32/tree/master/STM32F4)
-and compiling examples from the Arduino IDE. Note that the `stlink` is
-necessary to upload sketches to the microcontroller.
+board](https://www.st.com/en/evaluation-tools/nucleo-f401re.html) using the official
+[STM32duino core](https://github.com/stm32duino/Arduino_Core_STM32) (PlatformIO
+`ststm32` platform, see `env:nucleo_f401re` in [platformio.ini](platformio.ini)) and
+compiling examples from the Arduino IDE. Note that the `stlink` is necessary to upload
+sketches to the micro controller.
 
 ### Raspberry Pi Pico
 
@@ -1104,10 +1106,10 @@ Even at 16-bit resolution the PWM frequency stays above 1 kHz, producing smooth 
 output on LEDs. The Pico supports up to 16 PWM channels in parallel. See the
 [pico-demo](examples/raspi_pico) for an example and build instructions.
 
-When using the **Arduino framework** on the RP2040 (Earle Philhower arduino-pico SDK),
-`JLedHD` maps to `ArduinoHal<16>` (16-bit) instead. The `analogWriteResolution` global
-constraint described above applies in this case. See [platformio.ini](platformio.ini) for
-details (look for `env:raspberrypi_pico_w`, which targets the Raspberry Pi Pico W).
+`PicoHal` is used by default even when building through the **Arduino framework** (Earle
+Philhower arduino-pico SDK). To use the generic `ArduinoHal` instead, e.g. `JLedHD` as
+`ArduinoHal<16>`, define [`JLED_FORCE_ARDUINO_HAL`](#jled_force_arduino_hal); the
+`analogWriteResolution` global constraint described above then applies.
 
 ## Example sketches
 
@@ -1211,7 +1213,7 @@ led.Stop(jled::eIdleMode::KEEP_CURRENT);
 ```
 
 Reason: otherwise we would have separate `eStopMode` enums for `JLed`, `JLedHD` etc.
-classes, bloating the code.
+classes, bloating users code.
 
 #### JLedSequence to JLedGroup migration
 

--- a/README.md
+++ b/README.md
@@ -638,10 +638,12 @@ will be inverted (i.e., instead of x, the value of `FullBrightness - x` will be
 set, where `FullBrightness` is 255 for `JLed` and 65535 for `JLedHD`).
 Use `IsLowActive()` to query whether the LED is configured as low active.
 
-Inversion is performed by the HAL layer, via `InvertableHal`'s software
-fallback on all bundled platforms. This is transparent to `JLed`/`JLedHD`
-users; it only matters if you are writing a custom HAL, see the "New HAL"
-section in `CLAUDE.md`.
+Inversion is performed by the HAL layer: on ESP32 and Raspberry Pi Pico it is
+done in hardware (a GPIO-matrix / PWM-CSR polarity bit, armed once when
+`LowActive()` is called), with `InvertableHal`'s software fallback used on
+every other bundled platform. This is transparent to `JLed`/`JLedHD` users;
+it only matters if you are writing a custom HAL, see the "New HAL" section in
+`CLAUDE.md`.
 
 #### Minimum- and Maximum brightness level
 
@@ -1287,6 +1289,7 @@ class CustomJLed : public jled::TJLed<CustomHal, CustomJLed> { ... };
 // after
 class CustomHal {
     void analogWrite(uint8_t val, bool invert) const;  // millis() gone; invert added for low-active support
+    void SetLowActive(bool invert) const;  // new: required; no-op if there's no polarity register
 };
 class CustomJLed : public jled::TJLed<CustomHal, jled::JLedClockType, uint8_t, CustomJLed> { ... };
 ```
@@ -1294,7 +1297,7 @@ class CustomJLed : public jled::TJLed<CustomHal, jled::JLedClockType, uint8_t, C
 See the [custom_hal](examples/custom_hal) example for a complete implementation. See the
 [Low active for inverted output](#low-active-for-inverted-output) section for the
 `analogWrite(val, invert)` contract, and `InvertableHal<Hal>` if your HAL has no native inversion
-capability.
+capability (it implements `SetLowActive(bool)` as a no-op).
 
 Reason: a platform may have multiple PWM HALs (for example the built-in one plus an external PCA9685
 driver) but only a single clock. Separating them avoids duplicating time logic across HALs. Making

--- a/examples/custom_hal/custom_hal.ino
+++ b/examples/custom_hal/custom_hal.ino
@@ -1,18 +1,27 @@
 // JLed custom HAL example.
-// Copyright 2019,2025 by Jan Delgado. All rights reserved.
+// Copyright 2019-2026 by Jan Delgado. All rights reserved.
 // https://github.com/jandelgado/jled
 
 #include <jled.h>
 
-// a custom PWM HAL for the Arduino platform, inverting output.
-// In general, a JLed HAL class must satisfy the following interface:
+// a custom PWM HAL for the Arduino platform. In general, a JLed HAL class
+// must satisfy the following interface:
 //
 // class JLedHal {
 //   public:
 //     JLedHal(PinType pin);
-//     void analogWrite(uint8_t val) const;
+//
+//     template<typename Brightness>
+//     void analogWrite(Brightness val, bool invert) const;
+//
+//     void SetLowActive(bool invert) const;
 //  }
 //
+// analogWrite() receives an effect-space brightness value and whether the
+// connected LED is configured via LowActive(). It is entirely up to the HAL
+// how (or whether) it applies the inversion. This example applies it in
+// software, the same way jled::InvertableHal<Hal> does for any HAL that has
+// no native inversion support. Other HALs could do it in hardware.
 class CustomHal {
  public:
     using PinType = uint8_t;
@@ -20,21 +29,25 @@ class CustomHal {
     explicit CustomHal(PinType pin) noexcept : pin_(pin) {}
 
     template<typename Brightness>
-    void analogWrite(Brightness val) const {
+    void analogWrite(Brightness val, bool invert) const {
         // some platforms, e.g. STM need lazy initialization
         if (!setup_) {
             ::pinMode(pin_, OUTPUT);
             setup_ = true;
         }
-        // Scale to 8-bit and invert
+        // Scale to 8-bit
         uint8_t val8;
         if (sizeof(Brightness) == 1) {
             val8 = val;
         } else {
             val8 = static_cast<uint8_t>(val >> 8);
         }
-        ::analogWrite(pin_, 255 - val8);
+        ::analogWrite(pin_, invert ? 255 - val8 : val8);
     }
+
+    // No hardware polarity register on this platform; invert is already
+    // applied above on every analogWrite(), so there is nothing to do here.
+    void SetLowActive(bool) const {}
 
  private:
     mutable bool setup_ = false;
@@ -47,8 +60,9 @@ class CustomJLed : public jled::TJLed<CustomHal, jled::JLedClockType, uint8_t, C
     using jled::TJLed<CustomHal, jled::JLedClockType, uint8_t, CustomJLed>::TJLed;
 };
 
-// uses above defined CustomHal
-auto led = CustomJLed(LED_BUILTIN).Blink(1000, 1000).Repeat(5);
+// uses above defined CustomHal; LowActive() now works correctly since
+// CustomHal applies the invert flag CustomJLed passes it.
+auto led = CustomJLed(LED_BUILTIN).Blink(1000, 1000).Repeat(5).LowActive();
 
 void setup() {}
 

--- a/src/esp32_hal.h
+++ b/src/esp32_hal.h
@@ -32,11 +32,22 @@
 #pragma once
 
 #include <driver/ledc.h>
+#include <esp_idf_version.h>
 #include <esp_timer.h>
 #include <stdint.h>
 
 #include "brightness.h"
 #include "jled_std.h"
+
+// The LEDC driver's own output_invert flag (driver/ledc.h) is only available
+// starting with ESP-IDF v4.4 (added in
+// https://github.com/espressif/esp-idf/commit/48c848a1, absent from the v4.3
+// maintenance branch). Older SDKs have no documented hardware invert for
+// LEDC: on those, Esp32Hal below doesn't define analogWrite(val, invert) or
+// SetLowActive() at all, and jled.h wraps Esp32Hal in InvertableHal instead,
+// the same software-invert fallback used for Arduino/ESP8266/mbed.
+#define JLED_ESP32_HAS_LEDC_OUTPUT_INVERT \
+    (ESP_IDF_VERSION_MAJOR > 4 || (ESP_IDF_VERSION_MAJOR == 4 && ESP_IDF_VERSION_MINOR >= 4))
 
 namespace jled {
 
@@ -71,6 +82,9 @@ class Esp32ChanMapper {
         return (ledc_channel_t)i;
     }
 
+    PinType pinForChan(ledc_channel_t chan) const { return chanMap_[chan]; }
+    void registerPin(ledc_channel_t chan, PinType pin) { chanMap_[chan] = pin; }
+
  private:
     PinType nextChan_ = 0;
     PinType chanMap_[kLedcMaxChan];
@@ -102,8 +116,13 @@ class Esp32Hal : public Esp32HalBase {
     // freq  LEDC base frequency in Hz (default: 5000).
     // The PWM resolution (kResBits_) and timer (kTimer_) are template parameters.
     explicit Esp32Hal(PinType pin, int chan = kAutoSelectChan, uint16_t freq = 5000) noexcept {
-        chan_ = (chan == kAutoSelectChan) ? Esp32Hal::chanMapper().chanForPin(pin)
-                                          : (ledc_channel_t)chan;
+        if (chan == kAutoSelectChan) {
+            // chanForPin() already registers the pin for the channel it returns.
+            chan_ = Esp32Hal::chanMapper().chanForPin(pin);
+        } else {
+            chan_ = (ledc_channel_t)chan;
+            Esp32Hal::chanMapper().registerPin(chan_, pin);
+        }
 
         ledc_timer_config_t ledc_timer{};
         ledc_timer.speed_mode = kLedcSpeedMode;
@@ -115,17 +134,7 @@ class Esp32Hal : public Esp32HalBase {
 #endif
         ledc_timer_config(&ledc_timer);
 
-        ledc_channel_config_t ledc_channel{};
-        ledc_channel.gpio_num = pin;
-        ledc_channel.speed_mode = kLedcSpeedMode;
-        ledc_channel.channel = chan_;
-        ledc_channel.intr_type = LEDC_INTR_DISABLE;
-        ledc_channel.timer_sel = kTimer_;
-        ledc_channel.duty = 0;
-        ledc_channel.hpoint = 0;
-#if ESP_IDF_VERSION_MAJOR > 4
-        ledc_channel.flags.output_invert = 0;
-#endif
+        auto ledc_channel = makeChannelConfig(pin, 0);
         ledc_channel_config(&ledc_channel);
     }
 
@@ -149,10 +158,57 @@ class Esp32Hal : public Esp32HalBase {
         ledc_update_duty(kLedcSpeedMode, chan_);
     }
 
+#if JLED_ESP32_HAS_LEDC_OUTPUT_INVERT
+    template<typename Brightness>
+    void analogWrite(Brightness val, bool /*invert*/) const {
+        // Inversion is fully owned by SetLowActive()'s output_invert flag
+        // below; this HAL inverts in hardware, so it never needs to inspect
+        // invert on a per-call basis the way a software-fallback HAL would.
+        analogWrite(val);
+    }
+
+    // Inverts the channel's output in hardware via the LEDC driver's own
+    // output_invert flag. May be called at any time, including mid-effect
+    // (LowActive() can be toggled on and off), so it reads back the LEDC
+    // driver's own current duty/hpoint via ledc_get_duty()/ledc_get_hpoint()
+    // and writes them back unchanged, instead of caching them itself: this
+    // way the currently displayed brightness survives the polarity flip.
+    // A plain duty of 0 is the exception: at duty 0 the LEDC comparator
+    // never toggles, so output_invert has nothing to flip and the pin would
+    // stay low instead of the expected off/high; use the same full-duty
+    // value the full-on fix in analogWrite() uses so the invert actually
+    // applies, keeping the LED off by default in both polarities.
+    void SetLowActive(bool f) const {
+        const auto pin = chanMapper().pinForChan(chan_);
+        const auto duty = ledc_get_duty(kLedcSpeedMode, chan_);
+        auto ledc_channel = makeChannelConfig(pin, duty == 0 ? (f ? kMaxBrightness + 1 : 0) : duty);
+        ledc_channel.hpoint = ledc_get_hpoint(kLedcSpeedMode, chan_);
+        ledc_channel.flags.output_invert = f;
+        ledc_channel_config(&ledc_channel);
+    }
+#endif  // JLED_ESP32_HAS_LEDC_OUTPUT_INVERT
+
     PinType chan() const { return chan_; }
 
  private:
     static constexpr uint16_t kMaxBrightness = (1u << kResBits_) - 1;
+
+    // Builds the shared part of a ledc_channel_config_t. output_invert is
+    // deliberately left untouched here: that struct field only exists from
+    // ESP-IDF v4.4 on (see JLED_ESP32_HAS_LEDC_OUTPUT_INVERT), while this
+    // helper is also called unconditionally from the constructor.
+    ledc_channel_config_t makeChannelConfig(PinType pin, uint32_t duty) const {
+        ledc_channel_config_t ledc_channel{};
+        ledc_channel.gpio_num = pin;
+        ledc_channel.speed_mode = kLedcSpeedMode;
+        ledc_channel.channel = chan_;
+        ledc_channel.intr_type = LEDC_INTR_DISABLE;
+        ledc_channel.timer_sel = kTimer_;
+        ledc_channel.duty = duty;
+        ledc_channel.hpoint = 0;
+        return ledc_channel;
+    }
+
     ledc_channel_t chan_;
 };
 

--- a/src/esp32_hal.h
+++ b/src/esp32_hal.h
@@ -168,20 +168,15 @@ class Esp32Hal : public Esp32HalBase {
     }
 
     // Inverts the channel's output in hardware via the LEDC driver's own
-    // output_invert flag. May be called at any time, including mid-effect
-    // (LowActive() can be toggled on and off), so it reads back the LEDC
-    // driver's own current duty/hpoint via ledc_get_duty()/ledc_get_hpoint()
-    // and writes them back unchanged, instead of caching them itself: this
-    // way the currently displayed brightness survives the polarity flip.
-    // A plain duty of 0 is the exception: at duty 0 the LEDC comparator
-    // never toggles, so output_invert has nothing to flip and the pin would
-    // stay low instead of the expected off/high; use the same full-duty
-    // value the full-on fix in analogWrite() uses so the invert actually
-    // applies, keeping the LED off by default in both polarities.
+    // output_invert flag. ledc_channel_config() always writes a full
+    // channel config, so this reads back the current duty/hpoint first;
+    // otherwise the call would reset an in-flight duty to 0 instead of
+    // just flipping polarity. If the native LEDC flag misbehaves at some
+    // duty value on your chip, wrap this HAL in InvertableHal
+    // (src/invertable_hal.h) for a software fallback instead.
     void SetLowActive(bool f) const {
         const auto pin = chanMapper().pinForChan(chan_);
-        const auto duty = ledc_get_duty(kLedcSpeedMode, chan_);
-        auto ledc_channel = makeChannelConfig(pin, duty == 0 ? (f ? kMaxBrightness + 1 : 0) : duty);
+        auto ledc_channel = makeChannelConfig(pin, ledc_get_duty(kLedcSpeedMode, chan_));
         ledc_channel.hpoint = ledc_get_hpoint(kLedcSpeedMode, chan_);
         ledc_channel.flags.output_invert = f;
         ledc_channel_config(&ledc_channel);

--- a/src/invertable_hal.h
+++ b/src/invertable_hal.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2017-2026 Jan Delgado <jdelgado[at]gmx.net>
+// https://github.com/jandelgado/jled
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+#pragma once
+
+#include "brightness.h"  // BrightnessTraits
+
+namespace jled {
+
+// Adapts a HAL with a single-argument analogWrite(Color) to the two-argument
+// analogWrite(Color, bool invert) contract required by TJLed::WriteRaw(),
+// applying inversion in software. Stateless: computes the inverted value
+// inline on every call instead of caching the invert flag, so it adds no
+// data member of its own on top of Hal. Public inheritance keeps Hal's own
+// public members (e.g. Esp32Hal::chan(), HalMock::Value()/Pin()) reachable
+// through TJLed::GetHal(); using Hal::Hal reuses Hal's constructors.
+template<typename Hal>
+class InvertableHal : public Hal {
+ public:
+    using Hal::Hal;
+
+    template<typename Color>
+    void analogWrite(Color val, bool invert) const {
+        Hal::template analogWrite<Color>(
+            invert ? BrightnessTraits<Color>::kFullBrightness - val : val);
+    }
+};
+
+}  // namespace jled

--- a/src/invertable_hal.h
+++ b/src/invertable_hal.h
@@ -39,6 +39,10 @@ class InvertableHal : public Hal {
 
     template<typename Color>
     void analogWrite(Color val, bool invert) const {
+        // Unlike a HAL with native invert (e.g. Esp32Hal), which discards
+        // invert here because SetLowActive() already applied it in hardware,
+        // this is where invert actually gets applied: val is flipped in
+        // software before being forwarded to Hal's plain analogWrite(val).
         Hal::template analogWrite<Color>(invert ? BrightnessTraits<Color>::kFullBrightness - val
                                                 : val);
     }

--- a/src/invertable_hal.h
+++ b/src/invertable_hal.h
@@ -42,6 +42,10 @@ class InvertableHal : public Hal {
         Hal::template analogWrite<Color>(invert ? BrightnessTraits<Color>::kFullBrightness - val
                                                 : val);
     }
+
+    // Hal has no hardware polarity register; invert is already applied above
+    // on every analogWrite(), so there is nothing to pre-arm here.
+    void SetLowActive(bool) const {}
 };
 
 }  // namespace jled

--- a/src/invertable_hal.h
+++ b/src/invertable_hal.h
@@ -39,8 +39,8 @@ class InvertableHal : public Hal {
 
     template<typename Color>
     void analogWrite(Color val, bool invert) const {
-        Hal::template analogWrite<Color>(
-            invert ? BrightnessTraits<Color>::kFullBrightness - val : val);
+        Hal::template analogWrite<Color>(invert ? BrightnessTraits<Color>::kFullBrightness - val
+                                                : val);
     }
 };
 

--- a/src/jled.h
+++ b/src/jled.h
@@ -67,11 +67,8 @@ using JLedClockType = MbedClock;
 #elif defined(ESP32) && !defined(JLED_FORCE_ARDUINO_HAL)
 #include "esp32_hal.h"  // NOLINT
 namespace jled {
-// ESP32 LEDC has a hardware output-invert bit, but flipping it means a full
-// ledc_channel_config() re-init (duty read-back, hpoint, timer_sel) rather than
-// a cheap register write, so we rely on InvertableHal's software fallback.
-using JLedHal = InvertableHal<Esp32Hal<8, LEDC_TIMER_0> >;
-using JLedHalHD = InvertableHal<Esp32Hal<13, LEDC_TIMER_1> >;
+using JLedHal = Esp32Hal<8, LEDC_TIMER_0>;
+using JLedHalHD = Esp32Hal<13, LEDC_TIMER_1>;
 using JLedClockType = Esp32Clock;
 }  // namespace jled
 

--- a/src/jled.h
+++ b/src/jled.h
@@ -67,8 +67,15 @@ using JLedClockType = MbedClock;
 #elif defined(ESP32) && !defined(JLED_FORCE_ARDUINO_HAL)
 #include "esp32_hal.h"  // NOLINT
 namespace jled {
+#if JLED_ESP32_HAS_LEDC_OUTPUT_INVERT
 using JLedHal = Esp32Hal<8, LEDC_TIMER_0>;
 using JLedHalHD = Esp32Hal<13, LEDC_TIMER_1>;
+#else
+// Pre-4.4 ESP-IDF has no documented hardware invert for LEDC (see
+// esp32_hal.h); invert in software instead, same as Arduino/ESP8266/mbed.
+using JLedHal = InvertableHal<Esp32Hal<8, LEDC_TIMER_0> >;
+using JLedHalHD = InvertableHal<Esp32Hal<13, LEDC_TIMER_1> >;
+#endif
 using JLedClockType = Esp32Clock;
 }  // namespace jled
 

--- a/src/jled.h
+++ b/src/jled.h
@@ -67,8 +67,11 @@ using JLedClockType = MbedClock;
 #elif defined(ESP32) && !defined(JLED_FORCE_ARDUINO_HAL)
 #include "esp32_hal.h"  // NOLINT
 namespace jled {
-using JLedHal = Esp32Hal<8, LEDC_TIMER_0>;
-using JLedHalHD = Esp32Hal<13, LEDC_TIMER_1>;
+// ESP32 LEDC has a hardware output-invert bit, but flipping it means a full
+// ledc_channel_config() re-init (duty read-back, hpoint, timer_sel) rather than
+// a cheap register write, so we rely on InvertableHal's software fallback.
+using JLedHal = InvertableHal<Esp32Hal<8, LEDC_TIMER_0> >;
+using JLedHalHD = InvertableHal<Esp32Hal<13, LEDC_TIMER_1> >;
 using JLedClockType = Esp32Clock;
 }  // namespace jled
 

--- a/src/jled.h
+++ b/src/jled.h
@@ -32,6 +32,7 @@
 //     led.Update();
 //   }
 
+#include "invertable_hal.h"   // NOLINT
 #include "jled_base.h"        // NOLINT
 #include "jled_group_base.h"  // NOLINT
 #include "jled_std.h"         // NOLINT
@@ -56,8 +57,8 @@ using JLedClockType = PicoClock;
 #elif defined(__MBED__) && !defined(ARDUINO_API_VERSION)
 #include "mbed_hal.h"  // NOLINT
 namespace jled {
-using JLedHal = MbedHal<8>;
-using JLedHalHD = MbedHal<16>;
+using JLedHal = InvertableHal<MbedHal<8> >;
+using JLedHalHD = InvertableHal<MbedHal<16> >;
 using JLedClockType = MbedClock;
 }  // namespace jled
 
@@ -81,9 +82,9 @@ namespace jled {
 // All other Arduino-compatible platforms: 8-bit.
 #if defined(ESP8266) && \
     !(defined(HAS_ESP8266_VERSION_NUMERIC) && ARDUINO_ESP8266_VERSION_MAJOR >= 3)
-using JLedHal = ArduinoHal<10>;
+using JLedHal = InvertableHal<ArduinoHal<10> >;
 #else
-using JLedHal = ArduinoHal<8>;
+using JLedHal = InvertableHal<ArduinoHal<8> >;
 #endif
 // JLedHD uses the best practical PWM resolution per platform.
 // Bit-depth is chosen to keep PWM frequency well above the visible flicker
@@ -96,19 +97,19 @@ using JLedHal = ArduinoHal<8>;
 //     analogWriteResolution(), so JLedHD keeps full 10-bit resolution there.
 //   - All other Arduino-compatible platforms: 8-bit
 #if defined(ARDUINO_ARCH_RP2040)  // only hit if also JLED_FORCE_ARDUINO_HAL is set
-using JLedHalHD = ArduinoHal<16>;
+using JLedHalHD = InvertableHal<ArduinoHal<16> >;
 #elif defined(__IMXRT1062__) || defined(KINETISK) || defined(KINETISL)  // Teensy 4.x/3.x/LC
-using JLedHalHD = ArduinoHal<16>;  // frequency/resolution are independent on Teensy
+using JLedHalHD = InvertableHal<ArduinoHal<16> >;  // frequency/resolution are independent on Teensy
 #elif defined(__SAMD21__) || defined(ARDUINO_ARCH_SAM)  // SAMD21 (Zero, MKR), Arduino Due
-using JLedHalHD = ArduinoHal<12>;  // 12-bit -> ~11.7 kHz on 48 MHz GCLK (SAMD21) / 84 MHz (Due)
+using JLedHalHD = InvertableHal<ArduinoHal<12> >;  // 12-bit -> ~11.7 kHz on 48/84 MHz GCLK
 #elif defined(ARDUINO_ARCH_STM32)
-using JLedHalHD = ArduinoHal<12>;  // 12-bit avoids timer prescaler issues in STM32duino
+using JLedHalHD = InvertableHal<ArduinoHal<12> >;  // 12-bit avoids STM32duino prescaler issues
 #elif defined(ARDUINO_ARCH_NRF5)
-using JLedHalHD = ArduinoHal<12>;  // 16-bit -> ~244 Hz on nRF52; 12-bit -> ~3.9 kHz
+using JLedHalHD = InvertableHal<ArduinoHal<12> >;  // 16-bit -> ~244 Hz on nRF52; 12-bit -> ~3.9 kHz
 #elif defined(ESP8266)
-using JLedHalHD = ArduinoHal<10>;  // 10-bit on all core versions (see note above)
+using JLedHalHD = InvertableHal<ArduinoHal<10> >;  // 10-bit on all core versions (see note above)
 #else
-using JLedHalHD = ArduinoHal<8>;
+using JLedHalHD = InvertableHal<ArduinoHal<8> >;
 #endif
 using JLedClockType = ArduinoClock;
 }  // namespace jled

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -279,12 +279,14 @@ class TJLed : public JLedBase {
     // Returns current maximum brightness level.
     Brightness MaxBrightness() const { return maxBrightness_; }
 
-    // Write val directly out to the hardware, inverting signal when
-    // active-low is set. Bypasses the effect state machine entirely, e.g.
-    // for forcing an output from a lifecycle callback (see UpdateResult).
+    // Write val directly out to the hardware. Bypasses the effect state
+    // machine ("raw" = no Update()/Eval()), not that val is already in
+    // hardware-native units: turning the effect-space value into the final
+    // physical write (resolution scaling, and inversion for low-active
+    // wiring) is entirely the HAL's job. Used e.g. for forcing an output
+    // from a lifecycle callback (see UpdateResult).
     Derived& WriteRaw(Brightness val) {
-        constexpr auto kFullBright = BrightnessTraits<Brightness>::kFullBrightness;
-        hal_.template analogWrite<Brightness>(IsLowActive() ? kFullBright - val : val);
+        hal_.template analogWrite<Brightness>(val, IsLowActive());
         return static_cast<Derived&>(*this);
     }
 

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -103,9 +103,14 @@ class TJLed : public JLedBase {
     Hal& GetHal() { return hal_; }
 
     // Set physical LED polarity to be low active. This inverts every
-    // signal physically output to a pin.
+    // signal physically output to a pin. Every HAL must implement
+    // SetLowActive(bool); it is notified once here so a HAL with a hardware
+    // polarity register can pre-arm it instead of inspecting invert on every
+    // analogWrite(). HALs without one implement it as a no-op (see
+    // InvertableHal).
     Derived& LowActive() {
         bLowActive_ = true;
+        hal_.SetLowActive(bLowActive_);
         return static_cast<Derived&>(*this);
     }
 

--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -102,14 +102,14 @@ class TJLed : public JLedBase {
 
     Hal& GetHal() { return hal_; }
 
-    // Set physical LED polarity to be low active. This inverts every
-    // signal physically output to a pin. Every HAL must implement
+    // Set or clear physical LED low-active polarity. When on, every signal
+    // physically output to a pin is inverted. Every HAL must implement
     // SetLowActive(bool); it is notified once here so a HAL with a hardware
     // polarity register can pre-arm it instead of inspecting invert on every
     // analogWrite(). HALs without one implement it as a no-op (see
     // InvertableHal).
-    Derived& LowActive() {
-        bLowActive_ = true;
+    Derived& LowActive(bool on = true) {
+        bLowActive_ = on;
         hal_.SetLowActive(bLowActive_);
         return static_cast<Derived&>(*this);
     }
@@ -285,7 +285,7 @@ class TJLed : public JLedBase {
     Brightness MaxBrightness() const { return maxBrightness_; }
 
     // Write val directly out to the hardware. Bypasses the effect state
-    // machine ("raw" = no Update()/Eval()), not that val is already in
+    // machine ("raw" = no Update()/Eval()), note that val is already in
     // hardware-native units: turning the effect-space value into the final
     // physical write (resolution scaling, and inversion for low-active
     // wiring) is entirely the HAL's job. Used e.g. for forcing an output

--- a/src/pico_hal.h
+++ b/src/pico_hal.h
@@ -89,6 +89,21 @@ class PicoHal {
         pwm_set_chan_level(slice_num_, channel_, full_duty);
     }
 
+    template<typename Brightness>
+    void analogWrite(Brightness val, bool /*invert*/) const {
+        // Inversion is fully owned by SetLowActive()'s CSR bit below; this
+        // HAL inverts in hardware, so it never needs to inspect invert on a
+        // per-call basis the way a software-fallback HAL would.
+        analogWrite(val);
+    }
+
+    void SetLowActive(bool f) const {
+        const auto lsb = (channel_ == PWM_CHAN_A) ? PWM_CH0_CSR_A_INV_LSB : PWM_CH0_CSR_B_INV_LSB;
+        const auto bits =
+            (channel_ == PWM_CHAN_A) ? PWM_CH0_CSR_A_INV_BITS : PWM_CH0_CSR_B_INV_BITS;
+        hw_write_masked(&pwm_hw->slice[slice_num_].csr, bool_to_bit(f) << lsb, bits);
+    }
+
  private:
     uint8_t slice_num_, channel_;
 };

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,6 +25,11 @@ TEST_ESP32_SRC=esp-idf/esp_timer.cpp esp-idf/driver/ledc.cpp \
 			   test_esp32_hal.cpp test_main.cpp ${CATCH}
 TEST_ESP32_OBJECTS=$(TEST_ESP32_SRC:.cpp=.o)
 
+TEST_ESP32_LEGACY_SRC=esp-idf/esp_timer.cpp esp-idf/driver/ledc.cpp \
+			   esp32_mock.cpp \
+			   test_esp32_hal_legacy_idf.cpp test_main.cpp ${CATCH}
+TEST_ESP32_LEGACY_OBJECTS=$(TEST_ESP32_LEGACY_SRC:.cpp=.o)
+
 TEST_MBED_SRC=mbed.cpp test_mbed_hal.cpp test_main.cpp ${CATCH}
 TEST_MBED_OBJECTS=$(TEST_MBED_SRC:.cpp=.o)
 
@@ -54,7 +59,7 @@ TEST_JLED_GROUP_OBJECTS=$(TEST_JLED_GROUP_SRC:.cpp=.o)
 
 all: bin bin/test_arduino_mock  \
 	 bin/test_jled \
-	 bin/test_esp32_hal bin/test_arduino_hal bin/test_mbed_hal \
+	 bin/test_esp32_hal bin/test_esp32_hal_legacy_idf bin/test_arduino_hal bin/test_mbed_hal \
 	 bin/test_pico_hal bin/test_jled_esp8266_hal \
 	 bin/test_example_morse bin/test_brightness bin/test_fadeon_func \
 	 bin/test_invertable_hal bin/test_jled_group
@@ -68,6 +73,10 @@ bin/test_jled: $(TEST_JLED_OBJECTS)
 bin/test_esp32_hal: CFLAGS += -DESP32
 bin/test_esp32_hal: $(TEST_ESP32_OBJECTS)
 	$(CXX) -o $@ $(LDFLAGS) $(TEST_ESP32_OBJECTS)
+
+bin/test_esp32_hal_legacy_idf: CFLAGS += -DESP32
+bin/test_esp32_hal_legacy_idf: $(TEST_ESP32_LEGACY_OBJECTS)
+	$(CXX) -o $@ $(LDFLAGS) $(TEST_ESP32_LEGACY_OBJECTS)
 
 bin/test_mbed_hal: CFLAGS += -D__MBED__
 bin/test_mbed_hal: $(TEST_MBED_OBJECTS)
@@ -107,6 +116,7 @@ test: depend all
 	./bin/test_jled
 	./bin/test_mbed_hal
 	./bin/test_esp32_hal
+	./bin/test_esp32_hal_legacy_idf
 	./bin/test_arduino_hal
 	./bin/test_pico_hal
 	./bin/test_jled_esp8266_hal
@@ -134,7 +144,7 @@ clobber: clean
 
 depend: .depend
 
-.depend: $(TEST_JLED_SRC) $(TEST_ESP32_SRC) $(TEST_ESP8266_HAL_SRC) $(TEST_ARDUINO_SRC) $(TEST_INVERTABLE_HAL_SRC) $(TEST_MBED_SRC) $(TEST_PICO_SRC) $(TEST_MORSE_SRC) $(TEST_BRIGHTNESS_SRC) $(TEST_FADEON_SRC) $(TEST_JLED_GROUP_SRC)
+.depend: $(TEST_JLED_SRC) $(TEST_ESP32_SRC) $(TEST_ESP32_LEGACY_SRC) $(TEST_ESP8266_HAL_SRC) $(TEST_ARDUINO_SRC) $(TEST_INVERTABLE_HAL_SRC) $(TEST_MBED_SRC) $(TEST_PICO_SRC) $(TEST_MORSE_SRC) $(TEST_BRIGHTNESS_SRC) $(TEST_FADEON_SRC) $(TEST_JLED_GROUP_SRC)
 	@echo updating dependencies in .depend
 	@rm -f ./.depend
 	@$(CC) -I ../src -I . -I ./pico-sdk -MM $^ > .depend

--- a/test/Makefile
+++ b/test/Makefile
@@ -31,6 +31,9 @@ TEST_MBED_OBJECTS=$(TEST_MBED_SRC:.cpp=.o)
 TEST_ARDUINO_SRC=Arduino.cpp test_arduino_hal.cpp test_main.cpp ${CATCH}
 TEST_ARDUINO_OBJECTS=$(TEST_ARDUINO_SRC:.cpp=.o)
 
+TEST_INVERTABLE_HAL_SRC=Arduino.cpp test_invertable_hal.cpp test_main.cpp ${CATCH}
+TEST_INVERTABLE_HAL_OBJECTS=$(TEST_INVERTABLE_HAL_SRC:.cpp=.o)
+
 TEST_MORSE_SRC=test_example_morse.cpp test_main.cpp  ${CATCH}
 TEST_MORSE_OBJECTS=$(TEST_MORSE_SRC:.cpp=.o)
 
@@ -54,7 +57,7 @@ all: bin bin/test_arduino_mock  \
 	 bin/test_esp32_hal bin/test_arduino_hal bin/test_mbed_hal \
 	 bin/test_pico_hal bin/test_jled_esp8266_hal \
 	 bin/test_example_morse bin/test_brightness bin/test_fadeon_func \
-	 bin/test_jled_group
+	 bin/test_invertable_hal bin/test_jled_group
 
 bin/test_arduino_mock: $(TEST_ARDUINO_MOCK_OBJECTS)
 	$(CXX) -o $@ $(LDFLAGS) $(TEST_ARDUINO_MOCK_OBJECTS)
@@ -72,6 +75,9 @@ bin/test_mbed_hal: $(TEST_MBED_OBJECTS)
 
 bin/test_arduino_hal: $(TEST_ARDUINO_OBJECTS)
 	$(CXX) -o $@ $(LDFLAGS) $(TEST_ARDUINO_OBJECTS)
+
+bin/test_invertable_hal: $(TEST_INVERTABLE_HAL_OBJECTS)
+	$(CXX) -o $@ $(LDFLAGS) $(TEST_INVERTABLE_HAL_OBJECTS)
 
 bin/test_pico_hal: CFLAGS += -I./pico-sdk
 bin/test_pico_hal: $(TEST_PICO_OBJECTS)
@@ -107,6 +113,7 @@ test: depend all
 	./bin/test_example_morse
 	./bin/test_brightness
 	./bin/test_fadeon_func
+	./bin/test_invertable_hal
 	./bin/test_jled_group
 
 .cpp.o:
@@ -127,7 +134,7 @@ clobber: clean
 
 depend: .depend
 
-.depend: $(TEST_JLED_SRC) $(TEST_ESP32_SRC) $(TEST_ESP8266_HAL_SRC) $(TEST_ARDUINO_SRC) $(TEST_MBED_SRC) $(TEST_PICO_SRC) $(TEST_MORSE_SRC) $(TEST_BRIGHTNESS_SRC) $(TEST_FADEON_SRC) $(TEST_JLED_GROUP_SRC)
+.depend: $(TEST_JLED_SRC) $(TEST_ESP32_SRC) $(TEST_ESP8266_HAL_SRC) $(TEST_ARDUINO_SRC) $(TEST_INVERTABLE_HAL_SRC) $(TEST_MBED_SRC) $(TEST_PICO_SRC) $(TEST_MORSE_SRC) $(TEST_BRIGHTNESS_SRC) $(TEST_FADEON_SRC) $(TEST_JLED_GROUP_SRC)
 	@echo updating dependencies in .depend
 	@rm -f ./.depend
 	@$(CC) -I ../src -I . -I ./pico-sdk -MM $^ > .depend

--- a/test/esp-idf/driver/ledc.cpp
+++ b/test/esp-idf/driver/ledc.cpp
@@ -11,7 +11,10 @@ extern Esp32State* gState_;
 
 esp_err_t ledc_channel_config(const ledc_channel_config_t* ledc_conf) {
     assert(gState_);
+    assert(ledc_conf->channel >= LEDC_CHANNEL_0 && ledc_conf->channel < LEDC_CHANNEL_MAX);
     gState_->channel_config = *ledc_conf;
+    gState_->duty[ledc_conf->channel] = ledc_conf->duty;
+    gState_->hpoint[ledc_conf->channel] = ledc_conf->hpoint;
     return (esp_err_t)0;
 }
 
@@ -32,5 +35,18 @@ esp_err_t ledc_set_duty(ledc_mode_t speed_mode, ledc_channel_t channel, uint32_t
     assert(gState_);
     assert(channel >= LEDC_CHANNEL_0 && channel < LEDC_CHANNEL_MAX);
     gState_->set_duty[channel] = esp32_mock_ledc_set_duty_args{speed_mode, duty};
+    gState_->duty[channel] = duty;
     return (esp_err_t)0;
+}
+
+uint32_t ledc_get_duty(ledc_mode_t /*speed_mode*/, ledc_channel_t channel) {
+    assert(gState_);
+    assert(channel >= LEDC_CHANNEL_0 && channel < LEDC_CHANNEL_MAX);
+    return gState_->duty[channel];
+}
+
+int ledc_get_hpoint(ledc_mode_t /*speed_mode*/, ledc_channel_t channel) {
+    assert(gState_);
+    assert(channel >= LEDC_CHANNEL_0 && channel < LEDC_CHANNEL_MAX);
+    return gState_->hpoint[channel];
 }

--- a/test/esp-idf/driver/ledc.h
+++ b/test/esp-idf/driver/ledc.h
@@ -111,3 +111,6 @@ typedef struct {
     ledc_mode_t speed_mode;
     uint32_t duty;
 } esp32_mock_ledc_set_duty_args;
+
+uint32_t ledc_get_duty(ledc_mode_t speed_mode, ledc_channel_t channel);
+int ledc_get_hpoint(ledc_mode_t speed_mode, ledc_channel_t channel);

--- a/test/esp-idf/esp_idf_version.h
+++ b/test/esp-idf/esp_idf_version.h
@@ -1,0 +1,25 @@
+// Minimal ESP-IDF esp_idf_version.h mock for testing JLed's ESP-IDF
+// version-gated code paths (runs on host).
+// Copyright 2026 Jan Delgado jdelgado@gmx.net
+//
+// adapted from https://github.com/espressif/esp-idf include files
+// SPDX-FileCopyrightText: 2019-2022 Espressif Systems (Shanghai) CO LTD
+#pragma once
+
+// Unlike the real header (which bakes in the SDK's own version), the
+// defaults here can be overridden by #define-ing these before #include-ing
+// esp32_hal.h, so tests can target a specific ESP-IDF version.
+#ifndef ESP_IDF_VERSION_MAJOR
+#define ESP_IDF_VERSION_MAJOR 5
+#endif
+#ifndef ESP_IDF_VERSION_MINOR
+#define ESP_IDF_VERSION_MINOR 0
+#endif
+#ifndef ESP_IDF_VERSION_PATCH
+#define ESP_IDF_VERSION_PATCH 0
+#endif
+
+#define ESP_IDF_VERSION_VAL(major, minor, patch) (((major) << 16) | ((minor) << 8) | (patch))
+
+#define ESP_IDF_VERSION \
+    ESP_IDF_VERSION_VAL(ESP_IDF_VERSION_MAJOR, ESP_IDF_VERSION_MINOR, ESP_IDF_VERSION_PATCH)

--- a/test/esp32_mock.h
+++ b/test/esp32_mock.h
@@ -12,6 +12,11 @@ struct Esp32State {
     ledc_timer_config_t timer_config = {};
     esp32_mock_ledc_update_duty_args update_duty[LEDC_CHANNEL_MAX] = {};
     esp32_mock_ledc_set_duty_args set_duty[LEDC_CHANNEL_MAX] = {};
+    // Per-channel duty/hpoint as tracked by real LEDC hardware registers,
+    // written by both ledc_channel_config() and ledc_set_duty(), and read
+    // back by ledc_get_duty()/ledc_get_hpoint().
+    uint32_t duty[LEDC_CHANNEL_MAX] = {};
+    int hpoint[LEDC_CHANNEL_MAX] = {};
 
     void setTimer(int64_t t) { timer_us = t; }
     int64_t getTimer() const { return timer_us; }

--- a/test/hal_mock.h
+++ b/test/hal_mock.h
@@ -9,10 +9,13 @@
 #include "brightness.h"  // jled::BrightnessTraits
 
 // HalMock implements the JLed HAL protocol directly (analogWrite(val,
-// invert) + SetLowActive(bool)), applying inversion in software like any
-// plain HAL without a hardware polarity register would. It is not wrapped
-// in InvertableHal: that adapter is production code with its own dedicated
-// test (test_invertable_hal.cpp) and has no business in these state-machine
+// invert) + SetLowActive(bool)). It records the raw val and invert exactly
+// as passed, applying no inversion math of its own: whether a given call
+// site should see an inverted value is TJLed's decision, not the mock's, so
+// tests assert on the recorded (val, invert) pair rather than on a
+// re-derived physical output. It is not wrapped in InvertableHal: that
+// adapter is production code with its own dedicated test
+// (test_invertable_hal.cpp) and has no business in these state-machine
 // tests.
 class HalMock {
  public:
@@ -21,10 +24,12 @@ class HalMock {
     HalMock() {}
     explicit HalMock(PinType pin) : pin_(pin) {}
 
+    // -- JLed HAL protocol (see src/*_hal.h) --
+
     template<typename Brightness>
     void analogWrite(Brightness val, bool invert) const {
-        val_ = static_cast<uint16_t>(
-            invert ? jled::BrightnessTraits<Brightness>::kFullBrightness - val : val);
+        val_ = static_cast<uint16_t>(val);
+        invert_ = invert;
         pin_values()[pin_] = val_;
     }
 
@@ -33,8 +38,11 @@ class HalMock {
         set_low_active_value_ = f;
     }
 
+    // -- Mock-only introspection, not part of the HAL protocol --
+
     uint8_t Pin() const { return pin_; }
     uint16_t Value() const { return val_; }
+    bool Invert() const { return invert_; }
     int SetLowActiveCallCount() const { return set_low_active_call_count_; }
     bool SetLowActiveValue() const { return set_low_active_value_; }
 
@@ -49,6 +57,7 @@ class HalMock {
 
  private:
     mutable uint16_t val_ = 0;
+    mutable bool invert_ = false;
     PinType pin_ = 0;
     mutable int set_low_active_call_count_ = 0;
     mutable bool set_low_active_value_ = false;

--- a/test/hal_mock.h
+++ b/test/hal_mock.h
@@ -6,6 +6,14 @@
 #ifndef TEST_HAL_MOCK_H_
 #define TEST_HAL_MOCK_H_
 
+#include "brightness.h"  // jled::BrightnessTraits
+
+// HalMock implements the JLed HAL protocol directly (analogWrite(val,
+// invert) + SetLowActive(bool)), applying inversion in software like any
+// plain HAL without a hardware polarity register would. It is not wrapped
+// in InvertableHal: that adapter is production code with its own dedicated
+// test (test_invertable_hal.cpp) and has no business in these state-machine
+// tests.
 class HalMock {
  public:
     using PinType = uint8_t;
@@ -14,13 +22,21 @@ class HalMock {
     explicit HalMock(PinType pin) : pin_(pin) {}
 
     template<typename Brightness>
-    void analogWrite(Brightness val) const {
-        val_ = static_cast<uint16_t>(val);
+    void analogWrite(Brightness val, bool invert) const {
+        val_ = static_cast<uint16_t>(
+            invert ? jled::BrightnessTraits<Brightness>::kFullBrightness - val : val);
         pin_values()[pin_] = val_;
+    }
+
+    void SetLowActive(bool f) const {
+        set_low_active_call_count_++;
+        set_low_active_value_ = f;
     }
 
     uint8_t Pin() const { return pin_; }
     uint16_t Value() const { return val_; }
+    int SetLowActiveCallCount() const { return set_low_active_call_count_; }
+    bool SetLowActiveValue() const { return set_low_active_value_; }
 
     // Global pin-state table: allows reading back brightness from LEDs stored
     // inside type-erased containers (where GetHal() is not accessible).
@@ -34,6 +50,8 @@ class HalMock {
  private:
     mutable uint16_t val_ = 0;
     PinType pin_ = 0;
+    mutable int set_low_active_call_count_ = 0;
+    mutable bool set_low_active_value_ = false;
 
     static uint16_t* pin_values() {
         static uint16_t values[256] = {};

--- a/test/hal_mock.h
+++ b/test/hal_mock.h
@@ -14,7 +14,7 @@ class HalMock {
     explicit HalMock(PinType pin) : pin_(pin) {}
 
     template<typename Brightness>
-    void analogWrite(Brightness val) {
+    void analogWrite(Brightness val) const {
         val_ = static_cast<uint16_t>(val);
         pin_values()[pin_] = val_;
     }
@@ -32,7 +32,7 @@ class HalMock {
     }
 
  private:
-    uint16_t val_ = 0;
+    mutable uint16_t val_ = 0;
     PinType pin_ = 0;
 
     static uint16_t* pin_values() {

--- a/test/pico-sdk/hardware/pwm.h
+++ b/test/pico-sdk/hardware/pwm.h
@@ -5,11 +5,37 @@
 #include <stdint.h>
 
 typedef unsigned int uint;
+typedef uint32_t io_rw_32;
 
 #define PWM_CHAN_A 0u
 #define PWM_CHAN_B 1u
 
+// from hardware/regs/pwm.h (RP2040/RP2350, verified against the vendored
+// pico-sdk): PWM_CH0_CSR_A_INV / PWM_CH0_CSR_B_INV fields. "CH0" in the macro
+// name is the register template's name, not slice-specific; it applies
+// uniformly to every slice's csr register.
+#define PWM_CH0_CSR_A_INV_BITS 0x00000004u
+#define PWM_CH0_CSR_A_INV_LSB 2u
+#define PWM_CH0_CSR_B_INV_BITS 0x00000008u
+#define PWM_CH0_CSR_B_INV_LSB 3u
+
+// from pico/types.h
+#define bool_to_bit(x) ((uint) !!(x))
+
 typedef enum { GPIO_FUNC_PWM = 4 } gpio_function_t;
+
+// from hardware/structs/pwm.h: one memory-mapped CSR register per slice. The
+// mock only models the csr field, since that's all SetLowActive() touches.
+typedef struct {
+    io_rw_32 csr;
+} pwm_slice_hw_t;
+
+typedef struct {
+    pwm_slice_hw_t slice[8];
+} pwm_hw_t;
+
+extern pwm_hw_t pwm_hw_mock;
+#define pwm_hw (&pwm_hw_mock)
 
 uint pwm_gpio_to_slice_num(uint gpio);
 uint pwm_gpio_to_channel(uint gpio);
@@ -19,5 +45,8 @@ void pwm_set_wrap(uint slice_num, uint16_t wrap);
 void pwm_set_clkdiv_int_frac(uint slice_num, uint8_t integer, uint8_t fract);
 void pwm_set_enabled(uint slice_num, bool enabled);
 void pwm_set_chan_level(uint slice_num, uint chan, uint16_t level);
+
+// from hardware/address_mapped.h: masked register write (real signature).
+void hw_write_masked(io_rw_32* addr, uint32_t values, uint32_t write_mask);
 
 #endif  // PICO_SDK_HARDWARE_PWM_H_

--- a/test/pico_mock.cpp
+++ b/test/pico_mock.cpp
@@ -9,12 +9,23 @@
 #include "pico-sdk/pico/time.h"        // NOLINT
 
 static PicoState* gState_ = nullptr;
+pwm_hw_t pwm_hw_mock = {};
 
 void picoMockSetInstance(PicoState* state) {
     gState_ = state;
     if (state) {
         *state = PicoState{};
+        pwm_hw_mock = pwm_hw_t{};
     }
+}
+
+bool PicoState::getPwmInvert(uint32_t slice, uint32_t channel) const {
+    const auto lsb = (channel == PWM_CHAN_A) ? PWM_CH0_CSR_A_INV_LSB : PWM_CH0_CSR_B_INV_LSB;
+    return (pwm_hw_mock.slice[slice].csr >> lsb) & 1u;
+}
+
+void hw_write_masked(io_rw_32* addr, uint32_t values, uint32_t write_mask) {
+    *addr = (*addr & ~write_mask) | (values & write_mask);
 }
 
 // --- Pico SDK mock implementations ---

--- a/test/pico_mock.h
+++ b/test/pico_mock.h
@@ -30,6 +30,7 @@ struct PicoState {
     uint16_t getPwmChanLevel(uint32_t slice, uint32_t chan) const {
         return slices[slice].chan_level[chan];
     }
+    bool getPwmInvert(uint32_t slice, uint32_t channel) const;
 };
 
 // Register the active mock instance. Resets it to default values.

--- a/test/test_esp32_hal.cpp
+++ b/test/test_esp32_hal.cpp
@@ -163,17 +163,10 @@ TEST_CASE_METHOD(Esp32MockFixture, "Esp32Hal<8> SetLowActive", "[esp32_hal]") {
         REQUIRE(config.flags.output_invert == false);
     }
 
-    SECTION("SetLowActive(true) uses the full-duty value so the LED defaults off") {
-        // A plain duty of 0 never toggles the LEDC comparator, so
-        // output_invert would have nothing to flip and the pin would stay
-        // low (LED on for low active wiring) instead of off.
+    SECTION("SetLowActive() leaves a duty of 0 untouched") {
+        // No special-casing for duty 0: SetLowActive() just carries the
+        // current duty through unchanged, same as for any other value.
         hal.SetLowActive(true);
-        auto config = mock.getLedcChannelConfig();
-        REQUIRE(config.duty == 256);
-    }
-
-    SECTION("SetLowActive(false) uses a plain 0 duty so the LED defaults off") {
-        hal.SetLowActive(false);
         auto config = mock.getLedcChannelConfig();
         REQUIRE(config.duty == 0);
     }

--- a/test/test_esp32_hal.cpp
+++ b/test/test_esp32_hal.cpp
@@ -1,4 +1,5 @@
-// JLed Unit tests for the ESP32 HAL (runs on host).
+// JLed Unit tests for the ESP32 HAL (runs on host). See
+// test_esp32_hal_legacy_idf.cpp for the pre-4.4 ESP-IDF fallback path.
 // Copyright 2017-2025 Jan Delgado jdelgado@gmx.net
 #define ESP_IDF_VERSION_MAJOR 5
 #include <esp32_hal.h>  // NOLINT
@@ -138,6 +139,86 @@ TEST_CASE_METHOD(Esp32MockFixture, "Esp32Hal<13> analogWrite 16-bit", "[esp32_ha
         auto set_duty = mock.getLedcSetDuty((ledc_channel_t)kChan);
         REQUIRE(set_duty.duty == 4096);
     }
+}
+
+TEST_CASE_METHOD(Esp32MockFixture, "Esp32Hal<8> SetLowActive", "[esp32_hal]") {
+    constexpr auto kChan = 5;
+    constexpr auto kPin = 10;
+    auto hal = Esp32Hal<8>(kPin, kChan);
+
+    SECTION("SetLowActive(true) inverts via the LEDC output_invert flag") {
+        hal.SetLowActive(true);
+        auto config = mock.getLedcChannelConfig();
+        REQUIRE(config.gpio_num == kPin);
+        REQUIRE(config.channel == kChan);
+        REQUIRE(config.speed_mode == LEDC_LOW_SPEED_MODE);
+        REQUIRE(config.timer_sel == LEDC_TIMER_0);
+        REQUIRE(config.flags.output_invert == true);
+    }
+
+    SECTION("SetLowActive(false) clears inversion") {
+        hal.SetLowActive(true);
+        hal.SetLowActive(false);
+        auto config = mock.getLedcChannelConfig();
+        REQUIRE(config.flags.output_invert == false);
+    }
+
+    SECTION("SetLowActive(true) uses the full-duty value so the LED defaults off") {
+        // A plain duty of 0 never toggles the LEDC comparator, so
+        // output_invert would have nothing to flip and the pin would stay
+        // low (LED on for low active wiring) instead of off.
+        hal.SetLowActive(true);
+        auto config = mock.getLedcChannelConfig();
+        REQUIRE(config.duty == 256);
+    }
+
+    SECTION("SetLowActive(false) uses a plain 0 duty so the LED defaults off") {
+        hal.SetLowActive(false);
+        auto config = mock.getLedcChannelConfig();
+        REQUIRE(config.duty == 0);
+    }
+
+    SECTION("SetLowActive() preserves the currently displayed duty and hpoint") {
+        // toggling polarity mid-effect (LowActive() can be called at any
+        // time) must not force the LED to full on/off; it should only flip
+        // output_invert and leave the currently displayed duty untouched.
+        hal.analogWrite<uint8_t>(123);
+
+        hal.SetLowActive(true);
+        auto config = mock.getLedcChannelConfig();
+        REQUIRE(config.duty == 123);
+        REQUIRE(config.hpoint == 0);
+        REQUIRE(config.flags.output_invert == true);
+    }
+}
+
+TEST_CASE_METHOD(Esp32MockFixture, "Esp32Hal<8> SetLowActive with explicit channel construction",
+                 "[esp32_hal]") {
+    // Explicit (non auto-select) channel construction must still register the
+    // pin in Esp32ChanMapper, otherwise pinForChan() has nothing to return
+    // for SetLowActive()'s ledc_channel_config() call to use.
+    constexpr auto kChan = 3;
+    constexpr auto kPin = 22;
+    auto hal = Esp32Hal<8>(kPin, kChan);
+
+    hal.SetLowActive(true);
+    auto config = mock.getLedcChannelConfig();
+    REQUIRE(config.gpio_num == kPin);
+    REQUIRE(config.channel == kChan);
+}
+
+TEST_CASE_METHOD(Esp32MockFixture, "Esp32Hal<8> analogWrite ignores invert", "[esp32_hal]") {
+    constexpr auto kChan = 5;
+    constexpr auto kPin = 10;
+    auto hal = Esp32Hal<8>(kPin, kChan);
+
+    hal.analogWrite<uint8_t>(123, true);
+    const auto duty_true = mock.getLedcSetDuty((ledc_channel_t)kChan).duty;
+
+    hal.analogWrite<uint8_t>(123, false);
+    const auto duty_false = mock.getLedcSetDuty((ledc_channel_t)kChan).duty;
+
+    REQUIRE(duty_true == duty_false);
 }
 
 TEST_CASE_METHOD(Esp32MockFixture, "Esp32Clock::millis()", "[esp32_hal]") {

--- a/test/test_esp32_hal_legacy_idf.cpp
+++ b/test/test_esp32_hal_legacy_idf.cpp
@@ -1,0 +1,46 @@
+// JLed unit tests for Esp32Hal on pre-4.4 ESP-IDF, where the LEDC driver has
+// no output_invert flag (runs on host). jled.h wraps Esp32Hal in
+// InvertableHal on these SDKs (see esp32_hal.h), so that's what's under test
+// here; see test_esp32_hal.cpp for the native hardware-invert (ESP-IDF >=
+// 4.4) path, where Esp32Hal is used bare.
+// Copyright 2026 Jan Delgado jdelgado@gmx.net
+#define ESP_IDF_VERSION_MAJOR 4
+#define ESP_IDF_VERSION_MINOR 3
+#include <esp32_hal.h>  // NOLINT
+
+#include "catch2/catch_amalgamated.hpp"
+#include "esp32_mock.h"      // NOLINT
+#include "invertable_hal.h"  // NOLINT
+
+using jled::Esp32Hal;
+using jled::InvertableHal;
+
+// Pre-4.4, Esp32Hal has no analogWrite(val, invert) or SetLowActive() of its
+// own (see JLED_ESP32_HAS_LEDC_OUTPUT_INVERT in esp32_hal.h), so it doesn't
+// satisfy the mandatory HAL contract on its own; jled.h relies on the same
+// macro to decide to wrap it in InvertableHal instead.
+
+struct Esp32LegacyMockFixture {
+    Esp32State mock{};
+    Esp32LegacyMockFixture() { esp32MockSetInstance(&mock); }
+    ~Esp32LegacyMockFixture() { esp32MockSetInstance(nullptr); }
+};
+
+TEST_CASE_METHOD(Esp32LegacyMockFixture, "InvertableHal<Esp32Hal<8>> pre-4.4 ESP-IDF fallback",
+                 "[esp32_hal]") {
+    constexpr auto kChan = 5;
+    constexpr auto kPin = 10;
+    auto hal = InvertableHal<Esp32Hal<8>>(kPin, kChan);
+
+    SECTION("analogWrite(val, false) passes the value through unchanged") {
+        hal.analogWrite<uint8_t>(100, false);
+        REQUIRE(mock.getLedcSetDuty((ledc_channel_t)kChan).duty == 100);
+    }
+
+    SECTION("analogWrite(val, true) inverts the value in software") {
+        hal.analogWrite<uint8_t>(0, true);
+        // 0 inverted is 255 (full brightness), triggering the same full-on
+        // fix a plain analogWrite(255) would.
+        REQUIRE(mock.getLedcSetDuty((ledc_channel_t)kChan).duty == 256);
+    }
+}

--- a/test/test_invertable_hal.cpp
+++ b/test/test_invertable_hal.cpp
@@ -1,9 +1,8 @@
 // JLed unit tests for the InvertableHal<Hal> adapter (run on host).
 // Copyright 2026 Jan Delgado jdelgado@gmx.net
-#include <invertable_hal.h>  // NOLINT
-
 #include <Arduino.h>
-#include <arduino_hal.h>  // NOLINT
+#include <arduino_hal.h>     // NOLINT
+#include <invertable_hal.h>  // NOLINT
 
 #include "catch2/catch_amalgamated.hpp"
 #include "hal_mock.h"  // NOLINT

--- a/test/test_invertable_hal.cpp
+++ b/test/test_invertable_hal.cpp
@@ -1,0 +1,76 @@
+// JLed unit tests for the InvertableHal<Hal> adapter (run on host).
+// Copyright 2026 Jan Delgado jdelgado@gmx.net
+#include <invertable_hal.h>  // NOLINT
+
+#include <Arduino.h>
+#include <arduino_hal.h>  // NOLINT
+
+#include "catch2/catch_amalgamated.hpp"
+#include "hal_mock.h"  // NOLINT
+
+using jled::ArduinoHal;
+using jled::InvertableHal;
+
+TEST_CASE("InvertableHal<HalMock> analogWrite", "[invertable_hal]") {
+    InvertableHal<HalMock> hal(1);
+
+    SECTION("passthrough when invert is false (uint8_t)") {
+        hal.analogWrite<uint8_t>(123, false);
+        REQUIRE(hal.Value() == 123);
+    }
+
+    SECTION("passthrough when invert is false (uint16_t)") {
+        hal.analogWrite<uint16_t>(12345, false);
+        REQUIRE(hal.Value() == 12345);
+    }
+
+    SECTION("inverts uint8_t value when invert is true") {
+        hal.analogWrite<uint8_t>(0, true);
+        REQUIRE(hal.Value() == 255);
+
+        hal.analogWrite<uint8_t>(255, true);
+        REQUIRE(hal.Value() == 0);
+
+        hal.analogWrite<uint8_t>(100, true);
+        REQUIRE(hal.Value() == 155);
+    }
+
+    SECTION("inverts uint16_t value when invert is true") {
+        hal.analogWrite<uint16_t>(0, true);
+        REQUIRE(hal.Value() == 65535);
+
+        hal.analogWrite<uint16_t>(65535, true);
+        REQUIRE(hal.Value() == 0);
+    }
+}
+
+struct ArduinoMockFixture {
+    ArduinoState mock{};
+    ArduinoMockFixture() { arduinoMockSetInstance(&mock); }
+    ~ArduinoMockFixture() { arduinoMockSetInstance(nullptr); }
+};
+
+TEST_CASE_METHOD(ArduinoMockFixture, "InvertableHal<ArduinoHal<8>> analogWrite",
+                 "[invertable_hal]") {
+    constexpr auto kPin = 10;
+    InvertableHal<ArduinoHal<8>> hal(kPin);
+
+    SECTION("first call sets pin mode to OUTPUT, same as unwrapped ArduinoHal") {
+        REQUIRE(mock.getPinMode(kPin) == 0);
+        hal.analogWrite<uint8_t>(123, false);
+        REQUIRE(mock.getPinMode(kPin) == OUTPUT);
+    }
+
+    SECTION("passes value through unchanged when invert is false") {
+        hal.analogWrite<uint8_t>(123, false);
+        REQUIRE(mock.getPinState(kPin) == 123);
+    }
+
+    SECTION("inverts value before forwarding when invert is true") {
+        hal.analogWrite<uint8_t>(0, true);
+        REQUIRE(mock.getPinState(kPin) == 255);
+
+        hal.analogWrite<uint8_t>(255, true);
+        REQUIRE(mock.getPinState(kPin) == 0);
+    }
+}

--- a/test/test_invertable_hal.cpp
+++ b/test/test_invertable_hal.cpp
@@ -5,13 +5,32 @@
 #include <invertable_hal.h>  // NOLINT
 
 #include "catch2/catch_amalgamated.hpp"
-#include "hal_mock.h"  // NOLINT
 
 using jled::ArduinoHal;
 using jled::InvertableHal;
 
-TEST_CASE("InvertableHal<HalMock> analogWrite", "[invertable_hal]") {
-    InvertableHal<HalMock> hal(1);
+// A plain HAL with the single-argument analogWrite(val) contract InvertableHal
+// adapts, i.e. a HAL with no native inversion capability of its own.
+class SingleArgHal {
+ public:
+    using PinType = uint8_t;
+
+    explicit SingleArgHal(PinType pin) : pin_(pin) {}
+
+    template<typename Brightness>
+    void analogWrite(Brightness val) const {
+        val_ = static_cast<uint16_t>(val);
+    }
+
+    uint16_t Value() const { return val_; }
+
+ private:
+    PinType pin_;
+    mutable uint16_t val_ = 0;
+};
+
+TEST_CASE("InvertableHal<SingleArgHal> analogWrite", "[invertable_hal]") {
+    InvertableHal<SingleArgHal> hal(1);
 
     SECTION("passthrough when invert is false (uint8_t)") {
         hal.analogWrite<uint8_t>(123, false);

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -903,6 +903,21 @@ TEST_CASE("LowActive() calls the HAL's SetLowActive() hook", "[jled]") {
     CHECK(jled.GetHal().SetLowActiveValue());
 }
 
+TEST_CASE("LowActive(false) restores normal, high active output", "[jled]") {
+    auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{0, 255});
+    TestJLed jled = TestJLed(1).UserFunc(&eval).LowActive().LowActive(false);
+
+    CHECK_FALSE(jled.IsLowActive());
+    CHECK(2 == jled.GetHal().SetLowActiveCallCount());
+    CHECK_FALSE(jled.GetHal().SetLowActiveValue());
+
+    jled.Update(0);
+    CHECK(0 == jled.GetHal().Value());
+
+    jled.Update(1);
+    CHECK(255 == jled.GetHal().Value());
+}
+
 TEST_CASE("effect with repeat 2 repeats sequence once", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20});
     TestJLed jled = TestJLed(10).UserFunc(&eval).Repeat(2);

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -12,20 +12,18 @@
 #include "brightness.h"
 #include "catch2/catch_amalgamated.hpp"
 #include "hal_mock.h"              // NOLINT
-#include "invertable_hal.h"        // NOLINT
 #include "mock_brightness_eval.h"  // NOLINT
 
-using jled::InvertableHal;
 using jled::TJLed;
 
-// TestJLed is a JLed class using the HalMock (wrapped for the analogWrite(val,
-// invert) contract) for tests. This allows to test the code abstracted from
-// the actual hardware in use.
-class TestJLed : public TJLed<InvertableHal<HalMock>, TimeMock, uint8_t, TestJLed> {
-    using TJLed<InvertableHal<HalMock>, TimeMock, uint8_t, TestJLed>::TJLed;
+// TestJLed is a JLed class using HalMock, which implements the HAL protocol
+// directly. This allows to test the code abstracted from the actual hardware
+// in use.
+class TestJLed : public TJLed<HalMock, TimeMock, uint8_t, TestJLed> {
+    using TJLed<HalMock, TimeMock, uint8_t, TestJLed>::TJLed;
 };
 // instanciate for test coverage measurement
-template class TJLed<InvertableHal<HalMock>, TimeMock, uint8_t, TestJLed>;
+template class TJLed<HalMock, TimeMock, uint8_t, TestJLed>;
 
 // Type aliases for 8-bit evaluators (used in tests)
 using BlinkBrightnessEvaluator = jled::BlinkBrightnessEvaluator<uint8_t>;
@@ -760,7 +758,7 @@ TEST_CASE("Stop() default mode is TO_MIN_BRIGHTNESS", "[jled]") {
 
 TEST_CASE("Stop() makes the next Update() fire kDone exactly once", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20, 30});
-    TestJLed jled = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval);
+    TestJLed jled = TestJLed(1).UserFunc(&eval);
 
     TimeMock::set_millis(0);
     auto r0 = jled.Update();  // running
@@ -782,7 +780,7 @@ TEST_CASE("Stop() makes the next Update() fire kDone exactly once", "[jled]") {
 
 TEST_CASE("OnDone callback fires once after Stop()", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20, 30});
-    TestJLed jled = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval);
+    TestJLed jled = TestJLed(1).UserFunc(&eval);
 
     int doneCount = 0;
     TimeMock::set_millis(0);
@@ -798,7 +796,7 @@ TEST_CASE("OnDone callback fires once after Stop()", "[jled]") {
 
 TEST_CASE("natural completion still fires kDone exactly once (regression)", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20});
-    TestJLed jled = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval);
+    TestJLed jled = TestJLed(1).UserFunc(&eval);
 
     int doneCount = 0;
     for (uint32_t t = 0; t < 5; t++) {
@@ -810,7 +808,7 @@ TEST_CASE("natural completion still fires kDone exactly once (regression)", "[jl
 
 TEST_CASE("Reset() re-arms kDone after a Stop()", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20, 30});
-    TestJLed jled = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval);
+    TestJLed jled = TestJLed(1).UserFunc(&eval);
 
     TimeMock::set_millis(0);
     jled.Update();
@@ -827,7 +825,7 @@ TEST_CASE("Reset() re-arms kDone after a Stop()", "[jled]") {
 }
 
 TEST_CASE("Stop() on an effect-less LED fires no kDone", "[jled]") {
-    TestJLed jled = TestJLed(InvertableHal<HalMock>(1));  // no UserFunc/effect set
+    TestJLed jled = TestJLed(1);  // no UserFunc/effect set
     jled.Stop();
     TimeMock::set_millis(0);
     auto r = jled.Update();
@@ -895,6 +893,16 @@ TEST_CASE("WriteRaw() applies LowActive() inversion", "[jled]") {
     CHECK(0 == jled.GetHal().Value());
 }
 
+TEST_CASE("LowActive() calls the HAL's SetLowActive() hook", "[jled]") {
+    TestJLed jled(1);
+    CHECK(0 == jled.GetHal().SetLowActiveCallCount());
+
+    jled.LowActive();
+
+    CHECK(1 == jled.GetHal().SetLowActiveCallCount());
+    CHECK(jled.GetHal().SetLowActiveValue());
+}
+
 TEST_CASE("effect with repeat 2 repeats sequence once", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20});
     TestJLed jled = TestJLed(10).UserFunc(&eval).Repeat(2);
@@ -949,7 +957,7 @@ TEST_CASE("After calling Forever() the effect is repeated over and over again ",
 
 TEST_CASE("The Hal object provided in the ctor is used during update", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20});
-    TestJLed jled = TestJLed(InvertableHal<HalMock>(123)).UserFunc(&eval);
+    TestJLed jled = TestJLed(123).UserFunc(&eval);
 
     CHECK(jled.GetHal().Pin() == 123);
 }
@@ -1138,7 +1146,7 @@ TEST_CASE("lerp8by8 interpolates a byte into the given interval", "[lerp8by8]") 
 }
 
 TEST_CASE("Pause() during ST_RUNNING sets LED to minBrightness", "[jled]") {
-    TestJLed jled(InvertableHal<HalMock>(1));
+    TestJLed jled(1);
     jled.Blink(4, 4);  // on for t_cycle=0..3, off for t_cycle=4..7, done at t=8
 
     // Run to t=2 (mid-blink, brightness=255)
@@ -1158,7 +1166,7 @@ TEST_CASE("Pause() during ST_RUNNING sets LED to minBrightness", "[jled]") {
 }
 
 TEST_CASE("Resume() continues effect from freeze point", "[jled]") {
-    TestJLed jled(InvertableHal<HalMock>(1));
+    TestJLed jled(1);
     jled.Blink(4, 4);  // on=[0..3], off=[4..7], period=8
 
     // Advance to t=2 (elapsed=2, on-phase)
@@ -1183,7 +1191,7 @@ TEST_CASE("Resume() continues effect from freeze point", "[jled]") {
 }
 
 TEST_CASE("Pause() in ST_STOPPED is a no-op", "[jled]") {
-    TestJLed jled(InvertableHal<HalMock>(1));
+    TestJLed jled(1);
     jled.Blink(2, 2);
     jled.Update(0);
     jled.Stop();
@@ -1194,7 +1202,7 @@ TEST_CASE("Pause() in ST_STOPPED is a no-op", "[jled]") {
 }
 
 TEST_CASE("Pause() in ST_INIT delays effect start until Resume()", "[jled]") {
-    TestJLed jled(InvertableHal<HalMock>(1));
+    TestJLed jled(1);
     jled.Blink(2, 2);  // on=[0,1], off=[2,3], period=4
 
     TimeMock::set_millis(0);
@@ -1216,7 +1224,7 @@ TEST_CASE("Pause() in ST_INIT delays effect start until Resume()", "[jled]") {
 }
 
 TEST_CASE("Pause() is idempotent", "[jled]") {
-    TestJLed jled(InvertableHal<HalMock>(1));
+    TestJLed jled(1);
     jled.Blink(4, 4);
     jled.Update(0);  // time_start_=0
 
@@ -1233,7 +1241,7 @@ TEST_CASE("Pause() is idempotent", "[jled]") {
 }
 
 TEST_CASE("Resume() is idempotent", "[jled]") {
-    TestJLed jled(InvertableHal<HalMock>(1));
+    TestJLed jled(1);
     jled.Blink(4, 4);
     jled.Update(0);
     TimeMock::set_millis(1);
@@ -1250,7 +1258,7 @@ TEST_CASE("Resume() is idempotent", "[jled]") {
 }
 
 TEST_CASE("copy of paused JLed preserves pause state", "[jled]") {
-    TestJLed jled(InvertableHal<HalMock>(1));
+    TestJLed jled(1);
     jled.Blink(4, 4);
     jled.Update(0);
     jled.Update(2);
@@ -1269,7 +1277,7 @@ TEST_CASE("copy of paused JLed preserves pause state", "[jled]") {
 }
 
 TEST_CASE("Reset() clears pause state", "[jled]") {
-    TestJLed jled(InvertableHal<HalMock>(1));
+    TestJLed jled(1);
     jled.Blink(4, 4);
     jled.Update(0);
     TimeMock::set_millis(1);
@@ -1285,7 +1293,7 @@ TEST_CASE("Reset() clears pause state", "[jled]") {
 }
 
 TEST_CASE("Stop() clears pause state", "[jled]") {
-    TestJLed jled(InvertableHal<HalMock>(1));
+    TestJLed jled(1);
     jled.Blink(4, 4);
     jled.Update(0);
     TimeMock::set_millis(1);

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -12,17 +12,20 @@
 #include "brightness.h"
 #include "catch2/catch_amalgamated.hpp"
 #include "hal_mock.h"              // NOLINT
+#include "invertable_hal.h"        // NOLINT
 #include "mock_brightness_eval.h"  // NOLINT
 
+using jled::InvertableHal;
 using jled::TJLed;
 
-// TestJLed is a JLed class using the HalMock for tests. This allows to
-// test the code abstracted from the actual hardware in use.
-class TestJLed : public TJLed<HalMock, TimeMock, uint8_t, TestJLed> {
-    using TJLed<HalMock, TimeMock, uint8_t, TestJLed>::TJLed;
+// TestJLed is a JLed class using the HalMock (wrapped for the analogWrite(val,
+// invert) contract) for tests. This allows to test the code abstracted from
+// the actual hardware in use.
+class TestJLed : public TJLed<InvertableHal<HalMock>, TimeMock, uint8_t, TestJLed> {
+    using TJLed<InvertableHal<HalMock>, TimeMock, uint8_t, TestJLed>::TJLed;
 };
 // instanciate for test coverage measurement
-template class TJLed<HalMock, TimeMock, uint8_t, TestJLed>;
+template class TJLed<InvertableHal<HalMock>, TimeMock, uint8_t, TestJLed>;
 
 // Type aliases for 8-bit evaluators (used in tests)
 using BlinkBrightnessEvaluator = jled::BlinkBrightnessEvaluator<uint8_t>;
@@ -757,7 +760,7 @@ TEST_CASE("Stop() default mode is TO_MIN_BRIGHTNESS", "[jled]") {
 
 TEST_CASE("Stop() makes the next Update() fire kDone exactly once", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20, 30});
-    TestJLed jled = TestJLed(HalMock(1)).UserFunc(&eval);
+    TestJLed jled = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval);
 
     TimeMock::set_millis(0);
     auto r0 = jled.Update();  // running
@@ -779,7 +782,7 @@ TEST_CASE("Stop() makes the next Update() fire kDone exactly once", "[jled]") {
 
 TEST_CASE("OnDone callback fires once after Stop()", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20, 30});
-    TestJLed jled = TestJLed(HalMock(1)).UserFunc(&eval);
+    TestJLed jled = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval);
 
     int doneCount = 0;
     TimeMock::set_millis(0);
@@ -795,7 +798,7 @@ TEST_CASE("OnDone callback fires once after Stop()", "[jled]") {
 
 TEST_CASE("natural completion still fires kDone exactly once (regression)", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20});
-    TestJLed jled = TestJLed(HalMock(1)).UserFunc(&eval);
+    TestJLed jled = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval);
 
     int doneCount = 0;
     for (uint32_t t = 0; t < 5; t++) {
@@ -807,7 +810,7 @@ TEST_CASE("natural completion still fires kDone exactly once (regression)", "[jl
 
 TEST_CASE("Reset() re-arms kDone after a Stop()", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20, 30});
-    TestJLed jled = TestJLed(HalMock(1)).UserFunc(&eval);
+    TestJLed jled = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval);
 
     TimeMock::set_millis(0);
     jled.Update();
@@ -824,7 +827,7 @@ TEST_CASE("Reset() re-arms kDone after a Stop()", "[jled]") {
 }
 
 TEST_CASE("Stop() on an effect-less LED fires no kDone", "[jled]") {
-    TestJLed jled = TestJLed(HalMock(1));  // no UserFunc/effect set
+    TestJLed jled = TestJLed(InvertableHal<HalMock>(1));  // no UserFunc/effect set
     jled.Stop();
     TimeMock::set_millis(0);
     auto r = jled.Update();
@@ -946,7 +949,7 @@ TEST_CASE("After calling Forever() the effect is repeated over and over again ",
 
 TEST_CASE("The Hal object provided in the ctor is used during update", "[jled]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{10, 20});
-    TestJLed jled = TestJLed(HalMock(123)).UserFunc(&eval);
+    TestJLed jled = TestJLed(InvertableHal<HalMock>(123)).UserFunc(&eval);
 
     CHECK(jled.GetHal().Pin() == 123);
 }
@@ -1135,7 +1138,7 @@ TEST_CASE("lerp8by8 interpolates a byte into the given interval", "[lerp8by8]") 
 }
 
 TEST_CASE("Pause() during ST_RUNNING sets LED to minBrightness", "[jled]") {
-    TestJLed jled(HalMock(1));
+    TestJLed jled(InvertableHal<HalMock>(1));
     jled.Blink(4, 4);  // on for t_cycle=0..3, off for t_cycle=4..7, done at t=8
 
     // Run to t=2 (mid-blink, brightness=255)
@@ -1155,7 +1158,7 @@ TEST_CASE("Pause() during ST_RUNNING sets LED to minBrightness", "[jled]") {
 }
 
 TEST_CASE("Resume() continues effect from freeze point", "[jled]") {
-    TestJLed jled(HalMock(1));
+    TestJLed jled(InvertableHal<HalMock>(1));
     jled.Blink(4, 4);  // on=[0..3], off=[4..7], period=8
 
     // Advance to t=2 (elapsed=2, on-phase)
@@ -1180,7 +1183,7 @@ TEST_CASE("Resume() continues effect from freeze point", "[jled]") {
 }
 
 TEST_CASE("Pause() in ST_STOPPED is a no-op", "[jled]") {
-    TestJLed jled(HalMock(1));
+    TestJLed jled(InvertableHal<HalMock>(1));
     jled.Blink(2, 2);
     jled.Update(0);
     jled.Stop();
@@ -1191,7 +1194,7 @@ TEST_CASE("Pause() in ST_STOPPED is a no-op", "[jled]") {
 }
 
 TEST_CASE("Pause() in ST_INIT delays effect start until Resume()", "[jled]") {
-    TestJLed jled(HalMock(1));
+    TestJLed jled(InvertableHal<HalMock>(1));
     jled.Blink(2, 2);  // on=[0,1], off=[2,3], period=4
 
     TimeMock::set_millis(0);
@@ -1213,7 +1216,7 @@ TEST_CASE("Pause() in ST_INIT delays effect start until Resume()", "[jled]") {
 }
 
 TEST_CASE("Pause() is idempotent", "[jled]") {
-    TestJLed jled(HalMock(1));
+    TestJLed jled(InvertableHal<HalMock>(1));
     jled.Blink(4, 4);
     jled.Update(0);  // time_start_=0
 
@@ -1230,7 +1233,7 @@ TEST_CASE("Pause() is idempotent", "[jled]") {
 }
 
 TEST_CASE("Resume() is idempotent", "[jled]") {
-    TestJLed jled(HalMock(1));
+    TestJLed jled(InvertableHal<HalMock>(1));
     jled.Blink(4, 4);
     jled.Update(0);
     TimeMock::set_millis(1);
@@ -1247,7 +1250,7 @@ TEST_CASE("Resume() is idempotent", "[jled]") {
 }
 
 TEST_CASE("copy of paused JLed preserves pause state", "[jled]") {
-    TestJLed jled(HalMock(1));
+    TestJLed jled(InvertableHal<HalMock>(1));
     jled.Blink(4, 4);
     jled.Update(0);
     jled.Update(2);
@@ -1266,7 +1269,7 @@ TEST_CASE("copy of paused JLed preserves pause state", "[jled]") {
 }
 
 TEST_CASE("Reset() clears pause state", "[jled]") {
-    TestJLed jled(HalMock(1));
+    TestJLed jled(InvertableHal<HalMock>(1));
     jled.Blink(4, 4);
     jled.Update(0);
     TimeMock::set_millis(1);
@@ -1282,7 +1285,7 @@ TEST_CASE("Reset() clears pause state", "[jled]") {
 }
 
 TEST_CASE("Stop() clears pause state", "[jled]") {
-    TestJLed jled(HalMock(1));
+    TestJLed jled(InvertableHal<HalMock>(1));
     jled.Blink(4, 4);
     jled.Update(0);
     TimeMock::set_millis(1);

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -865,10 +865,12 @@ TEST_CASE("LowActive() inverts signal", "[jled]") {
     CHECK(jled.IsLowActive());
 
     jled.Update(0);
-    CHECK(255 == jled.GetHal().Value());
+    CHECK(0 == jled.GetHal().Value());
+    CHECK(jled.GetHal().Invert());
 
     jled.Update(1);
-    CHECK(0 == jled.GetHal().Value());
+    CHECK(255 == jled.GetHal().Value());
+    CHECK(jled.GetHal().Invert());
 }
 
 TEST_CASE("WriteRaw() writes directly to the HAL, bypassing the effect", "[jled]") {
@@ -887,10 +889,12 @@ TEST_CASE("WriteRaw() applies LowActive() inversion", "[jled]") {
     TestJLed jled = TestJLed(1).LowActive();
 
     jled.WriteRaw(0);
-    CHECK(255 == jled.GetHal().Value());
+    CHECK(0 == jled.GetHal().Value());
+    CHECK(jled.GetHal().Invert());
 
     jled.WriteRaw(255);
-    CHECK(0 == jled.GetHal().Value());
+    CHECK(255 == jled.GetHal().Value());
+    CHECK(jled.GetHal().Invert());
 }
 
 TEST_CASE("LowActive() calls the HAL's SetLowActive() hook", "[jled]") {
@@ -913,9 +917,11 @@ TEST_CASE("LowActive(false) restores normal, high active output", "[jled]") {
 
     jled.Update(0);
     CHECK(0 == jled.GetHal().Value());
+    CHECK_FALSE(jled.GetHal().Invert());
 
     jled.Update(1);
     CHECK(255 == jled.GetHal().Value());
+    CHECK_FALSE(jled.GetHal().Invert());
 }
 
 TEST_CASE("effect with repeat 2 repeats sequence once", "[jled]") {

--- a/test/test_jled_esp8266_hal.cpp
+++ b/test/test_jled_esp8266_hal.cpp
@@ -22,9 +22,9 @@
 // analogWriteResolution(). Before the fix, JLedHD wrongly fell back to 8-bit here.
 TEST_CASE("ESP8266 core v3+: JLed maps to 8-bit, JLedHD to 10-bit HAL", "[jled][esp8266]") {
     // Compile-time: a wrong HAL selection fails the build, not just the run.
-    static_assert(std::is_same<jled::JLedHal, jled::ArduinoHal<8>>::value,
-                  "JLed must use ArduinoHal<8> on ESP8266 core v3+");
-    static_assert(std::is_same<jled::JLedHalHD, jled::ArduinoHal<10>>::value,
-                  "JLedHD must use ArduinoHal<10> on ESP8266 core v3+");
+    static_assert(std::is_same<jled::JLedHal, jled::InvertableHal<jled::ArduinoHal<8>>>::value,
+                  "JLed must use InvertableHal<ArduinoHal<8>> on ESP8266 core v3+");
+    static_assert(std::is_same<jled::JLedHalHD, jled::InvertableHal<jled::ArduinoHal<10>>>::value,
+                  "JLedHD must use InvertableHal<ArduinoHal<10>> on ESP8266 core v3+");
     SUCCEED("ESP8266 core v3+ HAL selection verified at compile time");
 }

--- a/test/test_jled_group.cpp
+++ b/test/test_jled_group.cpp
@@ -5,16 +5,17 @@
 
 #include "catch2/catch_amalgamated.hpp"
 #include "hal_mock.h"              // NOLINT
+#include "invertable_hal.h"        // NOLINT
 #include "mock_brightness_eval.h"  // NOLINT
 
 using namespace jled;  // NOLINT
 
-class TestJLed : public TJLed<HalMock, TimeMock, uint8_t, TestJLed> {
-    using TJLed<HalMock, TimeMock, uint8_t, TestJLed>::TJLed;
+class TestJLed : public TJLed<InvertableHal<HalMock>, TimeMock, uint8_t, TestJLed> {
+    using TJLed<InvertableHal<HalMock>, TimeMock, uint8_t, TestJLed>::TJLed;
 };
 
-class TestJLedHD : public TJLed<HalMock, TimeMock, uint16_t, TestJLedHD> {
-    using TJLed<HalMock, TimeMock, uint16_t, TestJLedHD>::TJLed;
+class TestJLedHD : public TJLed<InvertableHal<HalMock>, TimeMock, uint16_t, TestJLedHD> {
+    using TJLed<InvertableHal<HalMock>, TimeMock, uint16_t, TestJLedHD>::TJLed;
 };
 
 namespace {
@@ -41,8 +42,8 @@ TEST_CASE("parallel group updates all elements simultaneously", "[jled_group]") 
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 50});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
     // Use pointer overload to cover Parallel(AnyType*, size_t)
     auto group = TestJLedGroupAny::Parallel(leds, 2);
 
@@ -61,8 +62,8 @@ TEST_CASE("sequential group plays elements one at a time", "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
     // Use array overload to cover Sequential(AnyType (&)[N])
     auto group = TestJLedGroupAny::Sequential(leds);
 
@@ -94,7 +95,7 @@ TEST_CASE("Repeat(n) plays the group n times", "[jled_group]") {
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
 
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{255, 0});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1).Repeat(2);
 
     constexpr uint8_t expected[] = {255, 0, 255, 0};
@@ -112,7 +113,7 @@ TEST_CASE("Forever plays group indefinitely", "[jled_group]") {
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
 
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{255, 0, 0});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1).Forever();
 
     constexpr uint8_t expected[] = {255, 0, 0};
@@ -128,7 +129,7 @@ TEST_CASE("Forever plays group indefinitely", "[jled_group]") {
 
 TEST_CASE("IsForever is false initially, true after Forever()", "[jled_group]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{255});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
     auto group = TestJLedGroupAny(mode, leds, 1);
     REQUIRE_FALSE(group.IsForever());
@@ -144,7 +145,7 @@ TEST_CASE("Reset restarts group from beginning", "[jled_group]") {
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
 
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
     auto group = TestJLedGroupAny(mode, leds, 1);
 
     TimeMock::set_millis(0);
@@ -169,7 +170,7 @@ TEST_CASE("Stop halts group execution and turns LEDs off", "[jled_group]") {
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
 
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
     auto group = TestJLedGroupAny(mode, leds, 1);
 
     TimeMock::set_millis(0);
@@ -189,8 +190,9 @@ TEST_CASE("nested JLedGroup within JLedGroup", "[jled_group]") {
     HalMock::Init();
     auto outer_eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto inner_eval = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny inner_leds[] = {TestJLed(HalMock(2)).UserFunc(&inner_eval).Repeat(1)};
-    TestJLedAny outer_leds[] = {TestJLed(HalMock(1)).UserFunc(&outer_eval).Repeat(1),
+    TestJLedAny inner_leds[] = {
+        TestJLed(InvertableHal<HalMock>(2)).UserFunc(&inner_eval).Repeat(1)};
+    TestJLedAny outer_leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&outer_eval).Repeat(1),
                                 TestJLedGroupAny::Parallel(inner_leds)};
     auto group = TestJLedGroupAny::Parallel(outer_leds);
 
@@ -208,7 +210,8 @@ TEST_CASE("nested JLedGroup within JLedGroup", "[jled_group]") {
 TEST_CASE("Stop(FULL_OFF) sets group LEDs to 0 regardless of MinBrightness", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
+    TestJLedAny leds[] = {
+        TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
     auto group = TestJLedGroupAny::Parallel(leds);
 
     TimeMock::set_millis(0);
@@ -221,7 +224,8 @@ TEST_CASE("Stop(FULL_OFF) sets group LEDs to 0 regardless of MinBrightness", "[j
 TEST_CASE("Stop(TO_MIN_BRIGHTNESS) sets group LEDs to minBrightness", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
+    TestJLedAny leds[] = {
+        TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
     auto group = TestJLedGroupAny::Parallel(leds);
 
     TimeMock::set_millis(0);
@@ -234,7 +238,7 @@ TEST_CASE("Stop(TO_MIN_BRIGHTNESS) sets group LEDs to minBrightness", "[jled_gro
 TEST_CASE("Stop(KEEP_CURRENT) leaves group LEDs at current brightness", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
     auto group = TestJLedGroupAny::Parallel(leds);
 
     TimeMock::set_millis(0);
@@ -249,8 +253,9 @@ TEST_CASE("Stop propagates to nested group and inner LEDs", "[jled_group]") {
     HalMock::Init();
     auto outer_eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto inner_eval = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny inner_leds[] = {TestJLed(HalMock(2)).UserFunc(&inner_eval).Repeat(1)};
-    TestJLedAny outer_leds[] = {TestJLed(HalMock(1)).UserFunc(&outer_eval).Repeat(1),
+    TestJLedAny inner_leds[] = {
+        TestJLed(InvertableHal<HalMock>(2)).UserFunc(&inner_eval).Repeat(1)};
+    TestJLedAny outer_leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&outer_eval).Repeat(1),
                                 TestJLedGroupAny::Parallel(inner_leds)};
     auto group = TestJLedGroupAny::Parallel(outer_leds);
 
@@ -269,7 +274,8 @@ TEST_CASE("JLedAny stores TestJLedHD and exercises 16-bit scale path", "[jled_gr
     HalMock::Init();
     // MaxBrightness(0x8000u) means lerp<uint16_t>(val, 0, 0x8000) calls scale<uint16_t>
     auto eval = MockBrightnessEvaluatorT<uint16_t>(std::vector<uint16_t>{32768u, 16384u});
-    TestJLedAny leds[] = {TestJLedHD(HalMock(1)).UserFunc(&eval).Repeat(1).MaxBrightness(0x8000u)};
+    TestJLedAny leds[] = {
+        TestJLedHD(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1).MaxBrightness(0x8000u)};
     auto group = TestJLedGroupAny::Parallel(leds);
 
     TimeMock::set_millis(0);
@@ -285,7 +291,7 @@ TEST_CASE("JLedAny copy constructor copies all state", "[jled_group]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{255, 0});
 
     SECTION("copy of JLed") {
-        TestJLedAny src(TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1));
+        TestJLedAny src(TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1));
         TestJLedAny arr[] = {src};
         TimeMock::set_millis(0);
         TestJLedGroupAny::Parallel(arr).Update(0);
@@ -293,7 +299,7 @@ TEST_CASE("JLedAny copy constructor copies all state", "[jled_group]") {
     }
 
     SECTION("copy of JLedGroup") {
-        TestJLedAny led_arr[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1)};
+        TestJLedAny led_arr[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
         TestJLedAny src(TestJLedGroupAny::Parallel(led_arr));
         TestJLedAny arr[] = {src};
         TimeMock::set_millis(0);
@@ -307,7 +313,7 @@ TEST_CASE("As<T>() recovers the concrete stored/referenced type", "[jled_group]"
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
 
     SECTION("TJLedAny holding a JLed") {
-        TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1)};
+        TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
 
         auto* led = leds[0].As<TestJLed>();
         REQUIRE(led != nullptr);
@@ -318,7 +324,7 @@ TEST_CASE("As<T>() recovers the concrete stored/referenced type", "[jled_group]"
     }
 
     SECTION("TJLedAny holding a nested group") {
-        TestJLedAny inner_leds[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1)};
+        TestJLedAny inner_leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
         TestJLedAny outer[] = {TestJLedGroupAny::Parallel(inner_leds).Forever()};
 
         auto* group = outer[0].As<TestJLedGroupAny>();
@@ -329,7 +335,7 @@ TEST_CASE("As<T>() recovers the concrete stored/referenced type", "[jled_group]"
     }
 
     SECTION("TJLedRef referencing a JLed") {
-        TestJLed led1 = TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1);
+        TestJLed led1 = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1);
 
         TJLedRef ref(&led1);
         REQUIRE(ref.As<TestJLed>() == &led1);
@@ -341,8 +347,8 @@ TEST_CASE("JLedRefGroup references externally managed LEDs", "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLed led1 = TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1);
-    TestJLed led2 = TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1);
+    TestJLed led1 = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1);
+    TestJLed led2 = TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1);
 
     SECTION("references to two LEDs") {
         TJLedRef refs[] = {&led1, &led2};
@@ -361,7 +367,7 @@ TEST_CASE("JLedRefGroup references externally managed LEDs", "[jled_group]") {
 
     SECTION("TJLedRef wraps a JLedGroup") {
         auto eval3 = MockBrightnessEvaluator(std::vector<uint8_t>{100, 0});
-        TestJLedAny inner_leds[] = {TestJLed(HalMock(3)).UserFunc(&eval3).Repeat(1)};
+        TestJLedAny inner_leds[] = {TestJLed(InvertableHal<HalMock>(3)).UserFunc(&eval3).Repeat(1)};
         TestJLedGroupAny inner_group = TestJLedGroupAny::Parallel(inner_leds);
 
         TJLedRef refs[] = {&led1, &inner_group};
@@ -423,7 +429,8 @@ TEST_CASE("JLedRefGroup references externally managed LEDs", "[jled_group]") {
 TEST_CASE("Pause() default mode is TO_MIN_BRIGHTNESS", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
+    TestJLedAny leds[] = {
+        TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
     auto group = TestJLedGroupAny::Parallel(leds);
 
     TimeMock::set_millis(0);
@@ -438,8 +445,8 @@ TEST_CASE("Pause() propagates to all children in parallel group", "[jled_group]"
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100, 50});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 75, 25});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Parallel(leds, 2);
 
     TimeMock::set_millis(0);
@@ -464,8 +471,8 @@ TEST_CASE("Resume() continues parallel group from freeze point", "[jled_group]")
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 50});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Parallel(leds, 2);
 
     // Advance to t=0 (elapsed=0, first values output)
@@ -488,8 +495,8 @@ TEST_CASE("Pause() freezes sequential group on current LED", "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Sequential(leds);
 
     TimeMock::set_millis(0);
@@ -528,8 +535,8 @@ TEST_CASE("Pause()/Resume() propagate through TJLedRef", "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 50});
-    TestJLed led1 = TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1);
-    TestJLed led2 = TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1);
+    TestJLed led1 = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1);
+    TestJLed led2 = TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1);
     TJLedRef refs[] = {&led1, &led2};
     auto group = TestJLedRefGroup::Parallel(refs);
 
@@ -560,7 +567,7 @@ TEST_CASE("Pause()/Resume() propagate through TJLedRef", "[jled_group]") {
 TEST_CASE("group kStart fires once, on the first Update() call", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     TimeMock::set_millis(0);
@@ -576,7 +583,7 @@ TEST_CASE("group kStart fires once, on the first Update() call", "[jled_group]")
 TEST_CASE("group kStart re-arms after Reset()", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     TimeMock::set_millis(0);
@@ -595,7 +602,7 @@ TEST_CASE("group kDone fires exactly once, on the terminal tick (natural complet
           "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     int doneCount = 0;
@@ -611,7 +618,7 @@ TEST_CASE("group kDone fires exactly once, on the terminal tick (natural complet
 TEST_CASE("group kDone fires on Update() after Stop(), exactly once", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100, 50, 25});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     TimeMock::set_millis(0);
@@ -649,7 +656,7 @@ TEST_CASE("empty group fires kStart and kDone together on its one Update() call"
 TEST_CASE("group kDone re-arms after Reset() for a second full run", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     TimeMock::set_millis(0);
@@ -666,7 +673,7 @@ TEST_CASE("group kDone re-arms after Reset() for a second full run", "[jled_grou
 TEST_CASE("group OnStart/OnDone chaining invokes callbacks", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     int startCount = 0, doneCount = 0;
@@ -689,7 +696,7 @@ TEST_CASE("GroupUpdateResult stays usable as a plain bool (backwards compatibili
           "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200});
-    TestJLedAny leds1[] = {TestJLed(HalMock(1)).UserFunc(&eval1)};
+    TestJLedAny leds1[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1)};
     auto group1 = TestJLedGroupAny::Parallel(leds1, 1);
 
     TimeMock::set_millis(0);
@@ -697,7 +704,7 @@ TEST_CASE("GroupUpdateResult stays usable as a plain bool (backwards compatibili
     CHECK_FALSE(x);  // single-tick element finishes on first tick
 
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds2[] = {TestJLed(HalMock(2)).UserFunc(&eval2)};
+    TestJLedAny leds2[] = {TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2)};
     auto group2 = TestJLedGroupAny::Parallel(leds2, 1);
 
     TimeMock::set_millis(0);
@@ -711,7 +718,7 @@ TEST_CASE("GroupUpdateResult stays usable as a plain bool (backwards compatibili
 TEST_CASE("group lifecycle events work through JLedRefGroup", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100, 50, 25});
-    TestJLed led1 = TestJLed(HalMock(1)).UserFunc(&eval).Repeat(1);
+    TestJLed led1 = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1);
     TJLedRef refs[] = {&led1};
     auto group = TestJLedRefGroup::Parallel(refs);
 
@@ -739,7 +746,7 @@ TEST_CASE("group kRepeatStart fires on the first Update() call, coincident with 
     HalMock::Init();
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1);
 
     TimeMock::set_millis(0);
@@ -761,7 +768,7 @@ TEST_CASE(
     HalMock::Init();
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1).Repeat(3);
 
     int repeatStartCount = 0;
@@ -779,7 +786,7 @@ TEST_CASE("group kRepeatStart does not fire on the terminal tick when no repetit
     HalMock::Init();
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1).Repeat(2);
 
     TimeMock::set_millis(0);
@@ -810,7 +817,7 @@ TEST_CASE("empty group also fires kRepeatStart together with kStart and kDone", 
 TEST_CASE("group kRepeatStart re-arms after Reset()", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Sequential(leds);
 
     TimeMock::set_millis(0);
@@ -827,7 +834,7 @@ TEST_CASE("group kRepeatStart re-arms after Reset()", "[jled_group]") {
 TEST_CASE("group OnRepeatStart callback invokes on each repetition boundary", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Sequential(leds).Repeat(2);
 
     int repeatStartCount = 0;
@@ -852,8 +859,8 @@ TEST_CASE("OnElementEnter/OnElementLeave report correct indices across a 2-eleme
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Sequential(leds);
 
     TimeMock::set_millis(0);
@@ -905,8 +912,8 @@ TEST_CASE("OnElementEnter/OnElementLeave indices are correct across a Repeat(2) 
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Sequential(leds).Repeat(2);
 
     TimeMock::set_millis(0);
@@ -954,8 +961,8 @@ TEST_CASE("OnElementEnter/OnElementLeave do not fire in PARALLEL mode", "[jled_g
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Parallel(leds, 2);
 
     int enterCount = 0, leaveCount = 0;
@@ -1012,7 +1019,7 @@ TEST_CASE(
     "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Sequential(leds).Repeat(2);
 
     TimeMock::set_millis(0);
@@ -1051,8 +1058,8 @@ TEST_CASE("OnElementEnter/OnElementLeave report correct indices regardless of ch
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
+                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Sequential(leds);
 
     TimeMock::set_millis(0);
@@ -1076,8 +1083,8 @@ TEST_CASE("OnElementLeave hands back the element for JLedRefGroup (As<T> recover
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLed led1 = TestJLed(HalMock(1)).UserFunc(&eval1).Repeat(1);
-    TestJLed led2 = TestJLed(HalMock(2)).UserFunc(&eval2).Repeat(1);
+    TestJLed led1 = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1);
+    TestJLed led2 = TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1);
     TJLedRef refs[] = {&led1, &led2};
     auto group = TestJLedRefGroup::Sequential(refs);
 
@@ -1103,7 +1110,7 @@ TEST_CASE(
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
     // single-tick element: every Update() call is a repetition boundary
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200});
-    TestJLedAny leds[] = {TestJLed(HalMock(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1).Repeat(3);
 
     TimeMock::set_millis(0);

--- a/test/test_jled_group.cpp
+++ b/test/test_jled_group.cpp
@@ -5,17 +5,16 @@
 
 #include "catch2/catch_amalgamated.hpp"
 #include "hal_mock.h"              // NOLINT
-#include "invertable_hal.h"        // NOLINT
 #include "mock_brightness_eval.h"  // NOLINT
 
 using namespace jled;  // NOLINT
 
-class TestJLed : public TJLed<InvertableHal<HalMock>, TimeMock, uint8_t, TestJLed> {
-    using TJLed<InvertableHal<HalMock>, TimeMock, uint8_t, TestJLed>::TJLed;
+class TestJLed : public TJLed<HalMock, TimeMock, uint8_t, TestJLed> {
+    using TJLed<HalMock, TimeMock, uint8_t, TestJLed>::TJLed;
 };
 
-class TestJLedHD : public TJLed<InvertableHal<HalMock>, TimeMock, uint16_t, TestJLedHD> {
-    using TJLed<InvertableHal<HalMock>, TimeMock, uint16_t, TestJLedHD>::TJLed;
+class TestJLedHD : public TJLed<HalMock, TimeMock, uint16_t, TestJLedHD> {
+    using TJLed<HalMock, TimeMock, uint16_t, TestJLedHD>::TJLed;
 };
 
 namespace {
@@ -42,8 +41,8 @@ TEST_CASE("parallel group updates all elements simultaneously", "[jled_group]") 
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 50});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval1).Repeat(1),
+                          TestJLed(2).UserFunc(&eval2).Repeat(1)};
     // Use pointer overload to cover Parallel(AnyType*, size_t)
     auto group = TestJLedGroupAny::Parallel(leds, 2);
 
@@ -62,8 +61,8 @@ TEST_CASE("sequential group plays elements one at a time", "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval1).Repeat(1),
+                          TestJLed(2).UserFunc(&eval2).Repeat(1)};
     // Use array overload to cover Sequential(AnyType (&)[N])
     auto group = TestJLedGroupAny::Sequential(leds);
 
@@ -95,7 +94,7 @@ TEST_CASE("Repeat(n) plays the group n times", "[jled_group]") {
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
 
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{255, 0});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1).Repeat(2);
 
     constexpr uint8_t expected[] = {255, 0, 255, 0};
@@ -113,7 +112,7 @@ TEST_CASE("Forever plays group indefinitely", "[jled_group]") {
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
 
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{255, 0, 0});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1).Forever();
 
     constexpr uint8_t expected[] = {255, 0, 0};
@@ -129,7 +128,7 @@ TEST_CASE("Forever plays group indefinitely", "[jled_group]") {
 
 TEST_CASE("IsForever is false initially, true after Forever()", "[jled_group]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{255});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
     auto group = TestJLedGroupAny(mode, leds, 1);
     REQUIRE_FALSE(group.IsForever());
@@ -145,7 +144,7 @@ TEST_CASE("Reset restarts group from beginning", "[jled_group]") {
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
 
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval).Repeat(1)};
     auto group = TestJLedGroupAny(mode, leds, 1);
 
     TimeMock::set_millis(0);
@@ -170,7 +169,7 @@ TEST_CASE("Stop halts group execution and turns LEDs off", "[jled_group]") {
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
 
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval).Repeat(1)};
     auto group = TestJLedGroupAny(mode, leds, 1);
 
     TimeMock::set_millis(0);
@@ -190,9 +189,8 @@ TEST_CASE("nested JLedGroup within JLedGroup", "[jled_group]") {
     HalMock::Init();
     auto outer_eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto inner_eval = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny inner_leds[] = {
-        TestJLed(InvertableHal<HalMock>(2)).UserFunc(&inner_eval).Repeat(1)};
-    TestJLedAny outer_leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&outer_eval).Repeat(1),
+    TestJLedAny inner_leds[] = {TestJLed(2).UserFunc(&inner_eval).Repeat(1)};
+    TestJLedAny outer_leds[] = {TestJLed(1).UserFunc(&outer_eval).Repeat(1),
                                 TestJLedGroupAny::Parallel(inner_leds)};
     auto group = TestJLedGroupAny::Parallel(outer_leds);
 
@@ -210,8 +208,7 @@ TEST_CASE("nested JLedGroup within JLedGroup", "[jled_group]") {
 TEST_CASE("Stop(FULL_OFF) sets group LEDs to 0 regardless of MinBrightness", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {
-        TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval).Repeat(1).MinBrightness(50)};
     auto group = TestJLedGroupAny::Parallel(leds);
 
     TimeMock::set_millis(0);
@@ -224,8 +221,7 @@ TEST_CASE("Stop(FULL_OFF) sets group LEDs to 0 regardless of MinBrightness", "[j
 TEST_CASE("Stop(TO_MIN_BRIGHTNESS) sets group LEDs to minBrightness", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {
-        TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval).Repeat(1).MinBrightness(50)};
     auto group = TestJLedGroupAny::Parallel(leds);
 
     TimeMock::set_millis(0);
@@ -238,7 +234,7 @@ TEST_CASE("Stop(TO_MIN_BRIGHTNESS) sets group LEDs to minBrightness", "[jled_gro
 TEST_CASE("Stop(KEEP_CURRENT) leaves group LEDs at current brightness", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval).Repeat(1)};
     auto group = TestJLedGroupAny::Parallel(leds);
 
     TimeMock::set_millis(0);
@@ -253,9 +249,8 @@ TEST_CASE("Stop propagates to nested group and inner LEDs", "[jled_group]") {
     HalMock::Init();
     auto outer_eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto inner_eval = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny inner_leds[] = {
-        TestJLed(InvertableHal<HalMock>(2)).UserFunc(&inner_eval).Repeat(1)};
-    TestJLedAny outer_leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&outer_eval).Repeat(1),
+    TestJLedAny inner_leds[] = {TestJLed(2).UserFunc(&inner_eval).Repeat(1)};
+    TestJLedAny outer_leds[] = {TestJLed(1).UserFunc(&outer_eval).Repeat(1),
                                 TestJLedGroupAny::Parallel(inner_leds)};
     auto group = TestJLedGroupAny::Parallel(outer_leds);
 
@@ -274,8 +269,7 @@ TEST_CASE("JLedAny stores TestJLedHD and exercises 16-bit scale path", "[jled_gr
     HalMock::Init();
     // MaxBrightness(0x8000u) means lerp<uint16_t>(val, 0, 0x8000) calls scale<uint16_t>
     auto eval = MockBrightnessEvaluatorT<uint16_t>(std::vector<uint16_t>{32768u, 16384u});
-    TestJLedAny leds[] = {
-        TestJLedHD(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1).MaxBrightness(0x8000u)};
+    TestJLedAny leds[] = {TestJLedHD(1).UserFunc(&eval).Repeat(1).MaxBrightness(0x8000u)};
     auto group = TestJLedGroupAny::Parallel(leds);
 
     TimeMock::set_millis(0);
@@ -291,7 +285,7 @@ TEST_CASE("JLedAny copy constructor copies all state", "[jled_group]") {
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{255, 0});
 
     SECTION("copy of JLed") {
-        TestJLedAny src(TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1));
+        TestJLedAny src(TestJLed(1).UserFunc(&eval).Repeat(1));
         TestJLedAny arr[] = {src};
         TimeMock::set_millis(0);
         TestJLedGroupAny::Parallel(arr).Update(0);
@@ -299,7 +293,7 @@ TEST_CASE("JLedAny copy constructor copies all state", "[jled_group]") {
     }
 
     SECTION("copy of JLedGroup") {
-        TestJLedAny led_arr[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
+        TestJLedAny led_arr[] = {TestJLed(1).UserFunc(&eval).Repeat(1)};
         TestJLedAny src(TestJLedGroupAny::Parallel(led_arr));
         TestJLedAny arr[] = {src};
         TimeMock::set_millis(0);
@@ -313,7 +307,7 @@ TEST_CASE("As<T>() recovers the concrete stored/referenced type", "[jled_group]"
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
 
     SECTION("TJLedAny holding a JLed") {
-        TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
+        TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval).Repeat(1)};
 
         auto* led = leds[0].As<TestJLed>();
         REQUIRE(led != nullptr);
@@ -324,7 +318,7 @@ TEST_CASE("As<T>() recovers the concrete stored/referenced type", "[jled_group]"
     }
 
     SECTION("TJLedAny holding a nested group") {
-        TestJLedAny inner_leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1)};
+        TestJLedAny inner_leds[] = {TestJLed(1).UserFunc(&eval).Repeat(1)};
         TestJLedAny outer[] = {TestJLedGroupAny::Parallel(inner_leds).Forever()};
 
         auto* group = outer[0].As<TestJLedGroupAny>();
@@ -335,7 +329,7 @@ TEST_CASE("As<T>() recovers the concrete stored/referenced type", "[jled_group]"
     }
 
     SECTION("TJLedRef referencing a JLed") {
-        TestJLed led1 = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1);
+        TestJLed led1 = TestJLed(1).UserFunc(&eval).Repeat(1);
 
         TJLedRef ref(&led1);
         REQUIRE(ref.As<TestJLed>() == &led1);
@@ -347,8 +341,8 @@ TEST_CASE("JLedRefGroup references externally managed LEDs", "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLed led1 = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1);
-    TestJLed led2 = TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1);
+    TestJLed led1 = TestJLed(1).UserFunc(&eval1).Repeat(1);
+    TestJLed led2 = TestJLed(2).UserFunc(&eval2).Repeat(1);
 
     SECTION("references to two LEDs") {
         TJLedRef refs[] = {&led1, &led2};
@@ -367,7 +361,7 @@ TEST_CASE("JLedRefGroup references externally managed LEDs", "[jled_group]") {
 
     SECTION("TJLedRef wraps a JLedGroup") {
         auto eval3 = MockBrightnessEvaluator(std::vector<uint8_t>{100, 0});
-        TestJLedAny inner_leds[] = {TestJLed(InvertableHal<HalMock>(3)).UserFunc(&eval3).Repeat(1)};
+        TestJLedAny inner_leds[] = {TestJLed(3).UserFunc(&eval3).Repeat(1)};
         TestJLedGroupAny inner_group = TestJLedGroupAny::Parallel(inner_leds);
 
         TJLedRef refs[] = {&led1, &inner_group};
@@ -429,8 +423,7 @@ TEST_CASE("JLedRefGroup references externally managed LEDs", "[jled_group]") {
 TEST_CASE("Pause() default mode is TO_MIN_BRIGHTNESS", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {
-        TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1).MinBrightness(50)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval).Repeat(1).MinBrightness(50)};
     auto group = TestJLedGroupAny::Parallel(leds);
 
     TimeMock::set_millis(0);
@@ -445,8 +438,8 @@ TEST_CASE("Pause() propagates to all children in parallel group", "[jled_group]"
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100, 50});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 75, 25});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval1).Repeat(1),
+                          TestJLed(2).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Parallel(leds, 2);
 
     TimeMock::set_millis(0);
@@ -471,8 +464,8 @@ TEST_CASE("Resume() continues parallel group from freeze point", "[jled_group]")
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 50});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval1).Repeat(1),
+                          TestJLed(2).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Parallel(leds, 2);
 
     // Advance to t=0 (elapsed=0, first values output)
@@ -495,8 +488,8 @@ TEST_CASE("Pause() freezes sequential group on current LED", "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval1).Repeat(1),
+                          TestJLed(2).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Sequential(leds);
 
     TimeMock::set_millis(0);
@@ -535,8 +528,8 @@ TEST_CASE("Pause()/Resume() propagate through TJLedRef", "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{150, 50});
-    TestJLed led1 = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1);
-    TestJLed led2 = TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1);
+    TestJLed led1 = TestJLed(1).UserFunc(&eval1).Repeat(1);
+    TestJLed led2 = TestJLed(2).UserFunc(&eval2).Repeat(1);
     TJLedRef refs[] = {&led1, &led2};
     auto group = TestJLedRefGroup::Parallel(refs);
 
@@ -567,7 +560,7 @@ TEST_CASE("Pause()/Resume() propagate through TJLedRef", "[jled_group]") {
 TEST_CASE("group kStart fires once, on the first Update() call", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     TimeMock::set_millis(0);
@@ -583,7 +576,7 @@ TEST_CASE("group kStart fires once, on the first Update() call", "[jled_group]")
 TEST_CASE("group kStart re-arms after Reset()", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     TimeMock::set_millis(0);
@@ -602,7 +595,7 @@ TEST_CASE("group kDone fires exactly once, on the terminal tick (natural complet
           "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     int doneCount = 0;
@@ -618,7 +611,7 @@ TEST_CASE("group kDone fires exactly once, on the terminal tick (natural complet
 TEST_CASE("group kDone fires on Update() after Stop(), exactly once", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100, 50, 25});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     TimeMock::set_millis(0);
@@ -656,7 +649,7 @@ TEST_CASE("empty group fires kStart and kDone together on its one Update() call"
 TEST_CASE("group kDone re-arms after Reset() for a second full run", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     TimeMock::set_millis(0);
@@ -673,7 +666,7 @@ TEST_CASE("group kDone re-arms after Reset() for a second full run", "[jled_grou
 TEST_CASE("group OnStart/OnDone chaining invokes callbacks", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Parallel(leds, 1);
 
     int startCount = 0, doneCount = 0;
@@ -696,7 +689,7 @@ TEST_CASE("GroupUpdateResult stays usable as a plain bool (backwards compatibili
           "[jled_group]") {
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200});
-    TestJLedAny leds1[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1)};
+    TestJLedAny leds1[] = {TestJLed(1).UserFunc(&eval1)};
     auto group1 = TestJLedGroupAny::Parallel(leds1, 1);
 
     TimeMock::set_millis(0);
@@ -704,7 +697,7 @@ TEST_CASE("GroupUpdateResult stays usable as a plain bool (backwards compatibili
     CHECK_FALSE(x);  // single-tick element finishes on first tick
 
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds2[] = {TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2)};
+    TestJLedAny leds2[] = {TestJLed(2).UserFunc(&eval2)};
     auto group2 = TestJLedGroupAny::Parallel(leds2, 1);
 
     TimeMock::set_millis(0);
@@ -718,7 +711,7 @@ TEST_CASE("GroupUpdateResult stays usable as a plain bool (backwards compatibili
 TEST_CASE("group lifecycle events work through JLedRefGroup", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100, 50, 25});
-    TestJLed led1 = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval).Repeat(1);
+    TestJLed led1 = TestJLed(1).UserFunc(&eval).Repeat(1);
     TJLedRef refs[] = {&led1};
     auto group = TestJLedRefGroup::Parallel(refs);
 
@@ -746,7 +739,7 @@ TEST_CASE("group kRepeatStart fires on the first Update() call, coincident with 
     HalMock::Init();
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1);
 
     TimeMock::set_millis(0);
@@ -768,7 +761,7 @@ TEST_CASE(
     HalMock::Init();
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1).Repeat(3);
 
     int repeatStartCount = 0;
@@ -786,7 +779,7 @@ TEST_CASE("group kRepeatStart does not fire on the terminal tick when no repetit
     HalMock::Init();
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1).Repeat(2);
 
     TimeMock::set_millis(0);
@@ -817,7 +810,7 @@ TEST_CASE("empty group also fires kRepeatStart together with kStart and kDone", 
 TEST_CASE("group kRepeatStart re-arms after Reset()", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Sequential(leds);
 
     TimeMock::set_millis(0);
@@ -834,7 +827,7 @@ TEST_CASE("group kRepeatStart re-arms after Reset()", "[jled_group]") {
 TEST_CASE("group OnRepeatStart callback invokes on each repetition boundary", "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Sequential(leds).Repeat(2);
 
     int repeatStartCount = 0;
@@ -859,8 +852,8 @@ TEST_CASE("OnElementEnter/OnElementLeave report correct indices across a 2-eleme
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval1).Repeat(1),
+                          TestJLed(2).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Sequential(leds);
 
     TimeMock::set_millis(0);
@@ -912,8 +905,8 @@ TEST_CASE("OnElementEnter/OnElementLeave indices are correct across a Repeat(2) 
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval1).Repeat(1),
+                          TestJLed(2).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Sequential(leds).Repeat(2);
 
     TimeMock::set_millis(0);
@@ -961,8 +954,8 @@ TEST_CASE("OnElementEnter/OnElementLeave do not fire in PARALLEL mode", "[jled_g
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval1).Repeat(1),
+                          TestJLed(2).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Parallel(leds, 2);
 
     int enterCount = 0, leaveCount = 0;
@@ -1019,7 +1012,7 @@ TEST_CASE(
     "[jled_group]") {
     HalMock::Init();
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny::Sequential(leds).Repeat(2);
 
     TimeMock::set_millis(0);
@@ -1058,8 +1051,8 @@ TEST_CASE("OnElementEnter/OnElementLeave report correct indices regardless of ch
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1),
-                          TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval1).Repeat(1),
+                          TestJLed(2).UserFunc(&eval2).Repeat(1)};
     auto group = TestJLedGroupAny::Sequential(leds);
 
     TimeMock::set_millis(0);
@@ -1083,8 +1076,8 @@ TEST_CASE("OnElementLeave hands back the element for JLedRefGroup (As<T> recover
     HalMock::Init();
     auto eval1 = MockBrightnessEvaluator(std::vector<uint8_t>{200, 100});
     auto eval2 = MockBrightnessEvaluator(std::vector<uint8_t>{50, 25});
-    TestJLed led1 = TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval1).Repeat(1);
-    TestJLed led2 = TestJLed(InvertableHal<HalMock>(2)).UserFunc(&eval2).Repeat(1);
+    TestJLed led1 = TestJLed(1).UserFunc(&eval1).Repeat(1);
+    TestJLed led2 = TestJLed(2).UserFunc(&eval2).Repeat(1);
     TJLedRef refs[] = {&led1, &led2};
     auto group = TestJLedRefGroup::Sequential(refs);
 
@@ -1110,7 +1103,7 @@ TEST_CASE(
     auto mode = GENERATE(TestJLedGroupAny::eMode::SEQUENCE, TestJLedGroupAny::eMode::PARALLEL);
     // single-tick element: every Update() call is a repetition boundary
     auto eval = MockBrightnessEvaluator(std::vector<uint8_t>{200});
-    TestJLedAny leds[] = {TestJLed(InvertableHal<HalMock>(1)).UserFunc(&eval)};
+    TestJLedAny leds[] = {TestJLed(1).UserFunc(&eval)};
     auto group = TestJLedGroupAny(mode, leds, 1).Repeat(3);
 
     TimeMock::set_millis(0);

--- a/test/test_pico_hal.cpp
+++ b/test/test_pico_hal.cpp
@@ -96,6 +96,52 @@ TEST_CASE_METHOD(PicoMockFixture, "PicoHal<16> analogWrite", "[pico_hal]") {
     }
 }
 
+TEST_CASE_METHOD(PicoMockFixture, "PicoHal<> SetLowActive", "[pico_hal]") {
+    PicoHal<> hal(kPin);  // pin 10 -> slice 5, channel A (0)
+
+    SECTION("SetLowActive(true) sets this channel's CSR invert bit") {
+        hal.SetLowActive(true);
+        REQUIRE(mock.getPwmInvert(kSlice, kChan) == true);
+    }
+
+    SECTION("SetLowActive(false) clears this channel's CSR invert bit") {
+        hal.SetLowActive(true);
+        hal.SetLowActive(false);
+        REQUIRE(mock.getPwmInvert(kSlice, kChan) == false);
+    }
+}
+
+TEST_CASE_METHOD(PicoMockFixture, "PicoHal<> SetLowActive does not clobber sibling channel",
+                 "[pico_hal]") {
+    // GPIO10 -> slice 5, channel A (0); GPIO11 -> slice 5, channel B (1)
+    PicoHal<> hal_a(10);
+    PicoHal<> hal_b(11);
+
+    hal_a.SetLowActive(true);
+    REQUIRE(mock.getPwmInvert(5, 0) == true);
+    REQUIRE(mock.getPwmInvert(5, 1) == false);
+
+    hal_b.SetLowActive(true);
+    REQUIRE(mock.getPwmInvert(5, 0) == true);  // hal_a's bit preserved
+    REQUIRE(mock.getPwmInvert(5, 1) == true);
+
+    hal_a.SetLowActive(false);
+    REQUIRE(mock.getPwmInvert(5, 0) == false);
+    REQUIRE(mock.getPwmInvert(5, 1) == true);  // hal_b's bit preserved
+}
+
+TEST_CASE_METHOD(PicoMockFixture, "PicoHal<> analogWrite ignores invert", "[pico_hal]") {
+    PicoHal<> hal(kPin);
+
+    hal.analogWrite<uint8_t>(123, true);
+    const auto level_true = mock.getPwmChanLevel(kSlice, kChan);
+
+    hal.analogWrite<uint8_t>(123, false);
+    const auto level_false = mock.getPwmChanLevel(kSlice, kChan);
+
+    REQUIRE(level_true == level_false);
+}
+
 TEST_CASE_METHOD(PicoMockFixture, "PicoClock::millis()", "[pico_hal]") {
     SECTION("returns 0 at boot") {
         mock.setBootTimeUs(0);


### PR DESCRIPTION
Signal inversion is currently handled by TJLed. But TJLeds main job is management of the state machine to play the effects. By moving the inversion logic to the HAL we also open the door to use hardware inversion on platforms, where this is possible (e.g. Raspberry PI Pico or ESP32). On other platforms, inversion is done in software (as before).
