### PR TITLE
fix: decorrelate candle flicker values from close-together offsets

### DIFF
--- a/src/jled_base.h
+++ b/src/jled_base.h
@@ -181,16 +181,21 @@ class TJLed : public JLedBase {
     }
 
     // Set effect to Candle light simulation.
-    // When offset is omitted, the address of this JLed instance is used as a
-    // random offset so multiple LEDs with default parameters automatically
-    // flicker independently. Pass an explicit offset (in ms) to control the
-    // phase precisely.
+    // When offset is omitted, a value derived from this instance's address
+    // and the current time is used, so multiple LEDs with default parameters
+    // automatically flicker independently, and the pattern also varies
+    // across power cycles (the address alone would be link-time fixed on
+    // most embedded targets and thus identical every boot). Pass an explicit
+    // offset (in ms) to control the phase precisely, e.g. to build a
+    // deliberate multi-LED wave/chase effect.
     Derived& Candle(uint8_t speed = 6, uint8_t jitter = 15, uint16_t period = 0xffff,
                     uint16_t offset = kCandleOffsetAuto) {
         eval_storage_.type = EvalType::CANDLE;
         const uint16_t actual_offset =
-            (offset == kCandleOffsetAuto) ? static_cast<uint16_t>(reinterpret_cast<uintptr_t>(this))
-                                          : offset;
+            (offset == kCandleOffsetAuto)
+                ? static_cast<uint16_t>(hash32(
+                      static_cast<uint32_t>(reinterpret_cast<uintptr_t>(this)) ^ Clock::millis()))
+                : offset;
         eval_storage_.data.candle =
             CandleBrightnessEvaluator<Brightness>(speed, jitter, period, actual_offset);
         return Reset();

--- a/src/jled_effects.cpp
+++ b/src/jled_effects.cpp
@@ -58,13 +58,15 @@ uint16_t fadeon_func<uint16_t>(uint32_t t, uint16_t period) {
     return lut_lerp(t, period, lut);
 }
 
-static uint8_t hash8(uint32_t x) {
+uint32_t hash32(uint32_t x) {
     x += 0x9e3779b9u;
     x ^= x >> 16;
     x *= 0x45d9f3bu;
     x ^= x >> 16;
-    return static_cast<uint8_t>(x);
+    return x;
 }
+
+static uint8_t hash8(uint32_t x) { return static_cast<uint8_t>(hash32(x)); }
 
 template<>
 uint8_t candle_func<uint8_t>(uint32_t t, uint8_t speed, uint8_t jitter) {

--- a/src/jled_effects.h
+++ b/src/jled_effects.h
@@ -86,6 +86,12 @@ Brightness fadeon_func(uint32_t t, uint16_t period);
 template<typename Brightness>
 Brightness candle_func(uint32_t t, uint8_t speed, uint8_t jitter);
 
+// Simple 32-bit integer hash (avalanche mix). Exposed so callers outside
+// jled_effects.cpp (e.g. TJLed::Candle()) can derive a well-spread
+// pseudo-random value from a small/related seed, such as an instance
+// address, without picking up the address's original small deltas.
+uint32_t hash32(uint32_t x);
+
 template<typename Brightness>
 Brightness scale(Brightness val, Brightness factor);
 

--- a/test/test_jled.cpp
+++ b/test/test_jled.cpp
@@ -185,6 +185,7 @@ TEST_CASE("using default Candle() configures CandleBrightnessEvaluator with semi
      public:
         using TestJLed::TestJLed;
         static void test() {
+            TimeMock::set_millis(0);
             TestableJLed jled(1);
             jled.Candle(1, 2, 3);
             REQUIRE(jled.eval_storage_.type == jled::EvalType::CANDLE);
@@ -192,8 +193,60 @@ TEST_CASE("using default Candle() configures CandleBrightnessEvaluator with semi
             CHECK(3 == eval.period_);
             CHECK(1 == eval.speed_);
             CHECK(2 == eval.jitter_);
-            // if no explicit offset is given, offset is initialized pseudo randomly
-            CHECK(static_cast<uint16_t>(reinterpret_cast<uintptr_t>(&jled)) == eval.offset_);
+            // if no explicit offset is given, offset is derived by hashing the
+            // instance's address together with the current time
+            const auto expected = static_cast<uint16_t>(jled::hash32(
+                static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&jled)) ^ TimeMock::millis()));
+            CHECK(expected == eval.offset_);
+        }
+    };
+    TestableJLed::test();
+}
+
+TEST_CASE(
+    "using default Candle() varies the auto-offset with construction time, not just the address",
+    "[jled]") {
+    // On most embedded targets an instance's address is fixed at link time,
+    // so it alone would reproduce the exact same flicker pattern every power
+    // cycle. Mixing in the current time avoids that.
+    class TestableJLed : public TestJLed {
+     public:
+        using TestJLed::TestJLed;
+        static void test() {
+            TestableJLed jled(1);
+
+            TimeMock::set_millis(0);
+            jled.Candle(1, 2, 3);
+            const auto offset_at_t0 = jled.eval_storage_.data.candle.offset_;
+
+            TimeMock::set_millis(12345);
+            jled.Candle(1, 2, 3);
+            const auto offset_at_t1 = jled.eval_storage_.data.candle.offset_;
+
+            CHECK(offset_at_t0 != offset_at_t1);
+        }
+    };
+    TestableJLed::test();
+}
+
+TEST_CASE("using default Candle() decorrelates offsets of adjacent instances", "[jled]") {
+    // Adjacent array elements have addresses only sizeof(TestJLed) apart. The
+    // auto-derived offset must not simply track that small, constant address
+    // delta (which is what previously caused adjacent LEDs to flicker as a
+    // visibly correlated, delayed copy of one another, looking like a wave).
+    class TestableJLed : public TestJLed {
+     public:
+        using TestJLed::TestJLed;
+        static void test() {
+            TimeMock::set_millis(0);
+            TestableJLed leds[3] = {TestableJLed(1), TestableJLed(2), TestableJLed(3)};
+            for (auto& led : leds) led.Candle(6, 15);
+
+            const auto o0 = leds[0].eval_storage_.data.candle.offset_;
+            const auto o1 = leds[1].eval_storage_.data.candle.offset_;
+            const auto o2 = leds[2].eval_storage_.data.candle.offset_;
+
+            CHECK(static_cast<uint16_t>(o1 - o0) != static_cast<uint16_t>(o2 - o1));
         }
     };
     TestableJLed::test();


### PR DESCRIPTION
application of the pseudo random offset to the candle effect was not so random at all and resulted in visible waves when multiple candles were run together. fixed by creating a creating a more random offset in the default case, while allowing for manual offsets to create the mentioned "wave" flickering effect, if wanted.